### PR TITLE
Adding btrfs to the e2e test matrix

### DIFF
--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -265,6 +265,14 @@ jobs:
       - name: Fetch example SQL datasets (locked)
         run: pnpm fetch:sql --lock
 
+      - name: Install btrfs tooling
+        if: matrix.snapshot_backend == 'btrfs'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y btrfs-progs
+
       - name: Resolve release versions
         id: version
         shell: bash

--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -241,6 +241,9 @@ jobs:
         scenario:
           - hp-psql-chinook
           - hp-psql-sakila
+        snapshot_backend:
+          - copy
+          - btrfs
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -312,6 +315,7 @@ jobs:
           esac
           node scripts/e2e-release/run-scenario.mjs \
             --scenario "${{ matrix.scenario }}" \
+            --snapshot-backend "${{ matrix.snapshot_backend }}" \
             --scenarios "test/e2e/release/scenarios.json" \
             --sqlrs "${{ steps.bundle.outputs.bundle_dir }}/sqlrs" \
             --engine "${{ steps.bundle.outputs.bundle_dir }}/sqlrs-engine" \
@@ -336,7 +340,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: e2e-linux-${{ matrix.scenario }}
+          name: e2e-linux-${{ matrix.scenario }}-${{ matrix.snapshot_backend }}
           if-no-files-found: warn
           path: |
             ${{ runner.temp }}/e2e/${{ matrix.scenario }}/command-init.txt

--- a/docs/adr/2026-02-16-release-happy-path-e2e-gating.md
+++ b/docs/adr/2026-02-16-release-happy-path-e2e-gating.md
@@ -5,6 +5,9 @@ Date: 2026-02-16
 
 ## Decision Record 1: MVP release gating scope by platform
 
+Status: Obsolete (superseded by
+[2026-02-19-release-e2e-btrfs-matrix.md](2026-02-19-release-e2e-btrfs-matrix.md))
+
 - Timestamp: 2026-02-16T16:38:17.8397425+07:00
 - User: @evilguest
 - Agent: Codex (GPT-5)

--- a/docs/adr/2026-02-19-release-e2e-btrfs-matrix.md
+++ b/docs/adr/2026-02-19-release-e2e-btrfs-matrix.md
@@ -1,0 +1,38 @@
+# ADR: release E2E btrfs matrix expansion
+
+Status: Accepted
+Date: 2026-02-19
+
+## Decision Record 1: next release-confidence direction
+
+- Timestamp: 2026-02-19T16:41:38.7698879+07:00
+- User: @evilguest
+- Agent: Codex (GPT-5)
+- Question: Which direction should be prioritized next to make release E2E more
+  convincing?
+- Alternatives:
+  - Expand full happy-path release blocking to all three platforms first.
+  - Replace fallback-only validation by adding Linux CoW/btrfs profile for existing
+    blocking scenarios.
+  - Add Liquibase release-blocking scenarios first.
+- Decision: Prioritize Linux CoW/btrfs validation for existing release-blocking
+  scenarios (`hp-psql-chinook`, `hp-psql-sakila`) before platform or Liquibase
+  expansion.
+- Rationale: This closes the biggest behavior gap between test path and real
+  snapshot path while keeping runtime and scenario surface stable.
+
+## Decision Record 2: workflow shape for btrfs coverage
+
+- Timestamp: 2026-02-19T16:41:38.7698879+07:00
+- User: @evilguest
+- Agent: Codex (GPT-5)
+- Question: How should btrfs coverage be integrated into release-local CI?
+- Alternatives:
+  - Add a separate dedicated Linux btrfs job outside current happy-path matrix.
+  - Expand current Linux happy-path job with matrix axis
+    `snapshot_backend: [copy, btrfs]`.
+  - Replace current copy profile entirely with btrfs-only runs.
+- Decision: Expand current Linux happy-path E2E with matrix axis
+  `snapshot_backend: [copy, btrfs]`, reusing same scenario catalog.
+- Rationale: Matrix keeps workflow structure simple, preserves baseline copy
+  profile, and makes backend coverage explicit per scenario.

--- a/scripts/e2e-release/release-local-workflow.test.mjs
+++ b/scripts/e2e-release/release-local-workflow.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import YAML from "yaml";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..", "..");
+const workflowPath = path.join(repoRoot, ".github", "workflows", "release-local.yml");
+
+function run(name, fn) {
+  try {
+    fn();
+    process.stdout.write(`ok - ${name}\n`);
+  } catch (err) {
+    process.stderr.write(`not ok - ${name}\n`);
+    throw err;
+  }
+}
+
+function loadWorkflow() {
+  const raw = fs.readFileSync(workflowPath, "utf8");
+  return YAML.parse(raw);
+}
+
+run("linux e2e matrix includes snapshot backend axis", () => {
+  const workflow = loadWorkflow();
+  const job = workflow.jobs?.["e2e-linux-happy"];
+  assert.ok(job, "missing e2e-linux-happy job");
+  assert.deepEqual(job.strategy?.matrix?.snapshot_backend, ["copy", "btrfs"]);
+});
+
+run("linux e2e passes snapshot backend to run-scenario", () => {
+  const workflow = loadWorkflow();
+  const job = workflow.jobs?.["e2e-linux-happy"];
+  const runStep = (job.steps || []).find((step) => step.name === "Run happy-path scenario");
+  assert.ok(runStep, "missing run step");
+  assert.match(String(runStep.run || ""), /--snapshot-backend "\$\{\{ matrix\.snapshot_backend \}\}"/);
+});
+
+run("linux diagnostics artifacts are backend-specific", () => {
+  const workflow = loadWorkflow();
+  const job = workflow.jobs?.["e2e-linux-happy"];
+  const uploadStep = (job.steps || []).find((step) => step.name === "Upload Linux E2E diagnostics");
+  assert.ok(uploadStep, "missing upload step");
+  assert.match(String(uploadStep.with?.name || ""), /\$\{\{ matrix\.snapshot_backend \}\}/);
+});

--- a/scripts/e2e-release/release-local-workflow.test.mjs
+++ b/scripts/e2e-release/release-local-workflow.test.mjs
@@ -46,3 +46,12 @@ run("linux diagnostics artifacts are backend-specific", () => {
   assert.ok(uploadStep, "missing upload step");
   assert.match(String(uploadStep.with?.name || ""), /\$\{\{ matrix\.snapshot_backend \}\}/);
 });
+
+run("linux btrfs profile installs required tooling", () => {
+  const workflow = loadWorkflow();
+  const job = workflow.jobs?.["e2e-linux-happy"];
+  const step = (job.steps || []).find((item) => item.name === "Install btrfs tooling");
+  assert.ok(step, "missing btrfs tooling step");
+  assert.equal(String(step.if || "").trim(), "matrix.snapshot_backend == 'btrfs'");
+  assert.match(String(step.run || ""), /apt-get install -y btrfs-progs/);
+});

--- a/scripts/e2e-release/run-scenario.test.mjs
+++ b/scripts/e2e-release/run-scenario.test.mjs
@@ -3,7 +3,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   buildInitCommand,
-  resolveSnapshotBackend
+  resolveSnapshotBackend,
+  resolveStorePlan
 } from "./run-scenario.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -45,4 +46,20 @@ run("default snapshot backend is copy", () => {
 
 run("unknown snapshot backend is rejected", () => {
   assert.throws(() => resolveSnapshotBackend("zfs"), /Invalid --snapshot-backend: zfs/);
+});
+
+run("btrfs backend uses dedicated loopback btrfs store plan", () => {
+  const outDir = path.join(path.sep, "tmp", "e2e-out");
+  const plan = resolveStorePlan("btrfs", outDir);
+  assert.equal(plan.mountType, "btrfs-loop");
+  assert.equal(plan.mountDir, path.join(outDir, "btrfs-store"));
+  assert.equal(plan.storeDir, path.join(outDir, "btrfs-store", "store"));
+  assert.equal(plan.imagePath, path.join(outDir, "btrfs-store.img"));
+});
+
+run("non-btrfs backend uses plain directory store plan", () => {
+  const outDir = path.join(path.sep, "tmp", "e2e-out");
+  const plan = resolveStorePlan("copy", outDir);
+  assert.equal(plan.mountType, "plain-dir");
+  assert.equal(plan.storeDir, path.join(outDir, "store"));
 });

--- a/scripts/e2e-release/run-scenario.test.mjs
+++ b/scripts/e2e-release/run-scenario.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildInitCommand,
+  resolveSnapshotBackend
+} from "./run-scenario.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function run(name, fn) {
+  try {
+    fn();
+    process.stdout.write(`ok - ${name}\n`);
+  } catch (err) {
+    process.stderr.write(`not ok - ${name}\n`);
+    throw err;
+  }
+}
+
+run("explicit btrfs backend is passed into init command", () => {
+  const sqlrsPath = path.join(__dirname, "fake-sqlrs");
+  const workspaceDir = path.join(__dirname, "tmp-workspace");
+  const enginePath = path.join(__dirname, "fake-engine");
+  const storeDir = path.join(__dirname, "tmp-store");
+
+  const cmd = buildInitCommand({
+    sqlrsPath,
+    workspaceDir,
+    enginePath,
+    storeDir,
+    snapshotBackend: resolveSnapshotBackend("btrfs")
+  });
+
+  const snapshotIndex = cmd.indexOf("--snapshot");
+  assert.notEqual(snapshotIndex, -1);
+  assert.equal(cmd[snapshotIndex + 1], "btrfs");
+});
+
+run("default snapshot backend is copy", () => {
+  assert.equal(resolveSnapshotBackend(undefined), "copy");
+  assert.equal(resolveSnapshotBackend(""), "copy");
+});
+
+run("unknown snapshot backend is rejected", () => {
+  assert.throws(() => resolveSnapshotBackend("zfs"), /Invalid --snapshot-backend: zfs/);
+});


### PR DESCRIPTION
# Summary
Enabled btrfs in e2e, to verify the mainstream flow within the Linux platform.