### PR TITLE
Implementing the ls command UI improvements

### DIFF
--- a/docs/adr/2026-03-03-cli-compact-tree-and-image-ids.md
+++ b/docs/adr/2026-03-03-cli-compact-tree-and-image-ids.md
@@ -1,0 +1,34 @@
+# ADR: Compact tree prefixes and IMAGE_ID shortening in CLI output
+
+- Conversation timestamp: 2026-03-03T13:52:39+07:00
+- GitHub user id: @evilguest
+- Agent: GPT-5.2 (Codex CLI)
+
+## Question
+
+How should `sqlrs ls --states` and `sqlrs rm` present state hierarchies and Docker image identifiers in human-readable output?
+
+## Alternatives considered
+
+### Tree rendering
+
+1. Keep `sqlrs ls --states` flat and keep the existing `sqlrs rm` tree style (`|--`, ``--`, 4-space indents).
+2. Use the same `|--` / ``--` style in both `sqlrs ls --states` and `sqlrs rm`.
+3. Use a compact tree prefix encoding with **one character per depth level** (`+`, `` ` ``, `|`, space) and use it consistently across commands.
+
+### IMAGE_ID formatting
+
+A. Print full `IMAGE_ID` values always.
+B. Shorten digest-based references in human output by default, keeping full values behind `--long`.
+
+## Decision
+
+- Adopt alternative 3 for human output: compact tree prefixes in both `sqlrs ls --states` and `sqlrs rm`.
+- Adopt IMAGE_ID alternative B: shorten digest-based `IMAGE_ID` values in human output unless `--long` is set.
+- Document that `sqlrs` `IMAGE_ID` is typically comparable to Docker `RepoDigests`, not to the Docker `IMAGE ID` column.
+
+## Rationale
+
+- Deep hierarchies remain readable in narrow terminals (e.g., <100 columns).
+- A single tree style across commands reduces cognitive load.
+- Compact `IMAGE_ID` keeps tables readable while `--long` preserves full fidelity.

--- a/docs/user-guides/sqlrs-ls.md
+++ b/docs/user-guides/sqlrs-ls.md
@@ -8,7 +8,8 @@ sqlrs manages five object types:
 
 - **states** - immutable database states produced by `prepare:psql`
 - **instances** - mutable database instances derived from states
-- **names** - stable user-defined handles pointing to instances (and bound to a state fingerprint)
+- **names** - stable user-defined handles pointing to instances (and bound to a
+  state fingerprint)
 - **jobs** - prepare job executions and their lifecycle
 - **tasks** - queued or running steps belonging to jobs
 
@@ -74,8 +75,8 @@ If no object selector flags are given, `sqlrs ls` lists:
 
 - `--names` and `--instances`
 
-Rationale: these are the objects users interact with most often. `--states` can be
-large (cache), and jobs/tasks are operational details, so they are shown explicitly.
+Rationale: these are the objects users interact with most often. `--states` can
+be large (cache), and jobs/tasks are operational details, so they are shown explicitly.
 
 ---
 
@@ -90,10 +91,40 @@ By default, `sqlrs ls` prints a table per selected object type, in this order:
 5. Tasks
 
 Each section begins with a one-line title (suppressed by `--quiet`).
-When `--quiet` is set and multiple sections are printed, sections are separated by a blank line.
+When `--quiet` is set and multiple sections are printed, sections are separated
+by a blank line.
 
 IDs are printed in lowercase. By default, human output shortens ids to 12
 characters. Use `--long` to print full ids.
+
+### IMAGE_ID formatting (human output)
+
+In human-readable output, `IMAGE_ID` can be displayed in a compact form to keep
+tables readable:
+
+- For digest references like `postgres@sha256:<64-hex>`, the short form is `postgres@<12-hex>`.
+- For raw digests like `sha256:<64-hex>`, the short form is `<12-hex>`.
+- For non-digest references (e.g. `postgres:16`), the value is printed as-is.
+
+Use `--long` to print the full `IMAGE_ID` values as returned by the engine.
+
+#### `IMAGE_ID` vs Docker identifiers
+
+`sqlrs ls` prints `IMAGE_ID` as a digest-based image reference (the value used
+by the engine for caching).
+This is typically comparable to Docker `RepoDigests`, not to the Docker `IMAGE ID`
+column.
+
+Examples (show both kinds of ids):
+
+```bash
+# Repo digests (comparable to sqlrs IMAGE_ID)
+docker image ls --digests postgres
+docker image inspect postgres --format '{{json .RepoDigests}}'
+
+# Local image id (config digest; often different)
+docker image inspect postgres --format '{{.Id}}'
+```
 
 ### Names table
 
@@ -138,6 +169,30 @@ Columns:
 - `CREATED`
 - `SIZE`
 - `REFCOUNT` (number of instances referencing this state)
+
+#### States hierarchy (human output)
+
+The `STATE_ID` column is rendered as a compact tree. The prefix uses
+**one character per depth level**:
+
+- `+` means “this node has following siblings” (not last)
+- `` ` `` means “last sibling”
+- `|` means “there are further siblings at this ancestor depth”
+- space means “no further siblings at this ancestor depth”
+
+When `ParentStateID` information is available, `sqlrs ls --states` renders
+`STATE_ID` as a tree to make
+parent/child relationships visible (similar to `sqlrs rm --recurse` output).
+For example:
+
+```text
+STATE_ID         IMAGE_ID             PREPARE_KIND  PREPARE_ARGS  CREATED  SIZE  REFCOUNT
+aaaaaaaaaaaa     postgres@7352e0c4d62b psql         ...          ...      ...   ...
++bbbbbbbbbbbb   postgres@7352e0c4d62b psql         ...          ...      ...   ...
+`cccccccccccc   postgres@7352e0c4d62b psql         ...          ...      ...   ...
+```
+
+For machine-readable processing, use `--output json`.
 
 ### Jobs table
 
@@ -311,8 +366,9 @@ sqlrs ls --all --output json
 
 ### Why separate `names` from `instances`?
 
-- Names are the *stable handles* users remember.
-- Instances are the *actual mutable databases* that may be ephemeral, expiring, or renamed.
+- Names are the _stable handles_ users remember.
+- Instances are the _actual mutable databases_ that may be ephemeral, expiring,
+  or renamed.
 - Keeping both visible makes lifecycle debugging straightforward.
 
 ### Why not list states by default?

--- a/docs/user-guides/sqlrs-rm.md
+++ b/docs/user-guides/sqlrs-rm.md
@@ -74,7 +74,12 @@ Flags:
 
 ## Output (Human)
 
-Human output is a tree:
+Human output is a compact tree (one character per depth level):
+
+- `+` means “this node has following siblings” (not last)
+- `` ` `` means “last sibling”
+- `|` means “there are further siblings at this ancestor depth”
+- space means “no further siblings at this ancestor depth”
 
 - `deleted` or `would delete` for successful actions
 - `blocked (<reason>)` for any node that cannot be deleted
@@ -84,8 +89,8 @@ Example (real deletion):
 
 ```text
 state 6b6f... deleted
-|-- instance 6b6f... deleted (connections=0)
-`-- state 6b6f... deleted
++ instance 6b6f... deleted (connections=0)
+` state 6b6f... deleted
 ```
 
 Example (job deletion):
@@ -98,7 +103,7 @@ Example (`--dry-run`):
 
 ```text
 state 6b6f... would delete
-`-- instance 6b6f... blocked (active_connections) (connections=2)
+` instance 6b6f... blocked (active_connections) (connections=2)
 ```
 
 If `--recurse` is not set, only the root node is shown.

--- a/frontend/cli-go/internal/cli/commands_ls.go
+++ b/frontend/cli-go/internal/cli/commands_ls.go
@@ -375,7 +375,7 @@ func printNamesTable(w io.Writer, rows []client.NameEntry, noHeader bool, longID
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			row.Name,
 			formatIDPtr(row.InstanceID, longIDs),
-			row.ImageID,
+			formatImageID(row.ImageID, longIDs),
 			formatID(stateID, longIDs),
 			row.Status,
 			optionalString(row.LastUsedAt),
@@ -392,7 +392,7 @@ func printInstancesTable(w io.Writer, rows []client.InstanceEntry, noHeader bool
 	for _, row := range rows {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 			formatID(row.InstanceID, longIDs),
-			row.ImageID,
+			formatImageID(row.ImageID, longIDs),
 			formatID(row.StateID, longIDs),
 			optionalString(row.Name),
 			row.CreatedAt,
@@ -408,17 +408,95 @@ func printStatesTable(w io.Writer, rows []client.StateEntry, noHeader bool, long
 	if !noHeader {
 		fmt.Fprintln(tw, "STATE_ID\tIMAGE_ID\tPREPARE_KIND\tPREPARE_ARGS\tCREATED\tSIZE\tREFCOUNT")
 	}
-	for _, row := range rows {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			formatID(row.StateID, longIDs),
-			row.ImageID,
-			row.PrepareKind,
-			row.PrepareArgs,
-			row.CreatedAt,
-			optionalInt64(row.SizeBytes),
-			strconv.Itoa(row.RefCount),
-		)
+
+	type stateNode struct {
+		key      string
+		row      client.StateEntry
+		parent   *stateNode
+		children []*stateNode
 	}
+
+	nodes := make([]*stateNode, 0, len(rows))
+	byID := make(map[string]*stateNode, len(rows))
+	for _, row := range rows {
+		key := strings.ToLower(strings.TrimSpace(row.StateID))
+		if key == "" {
+			continue
+		}
+		node := &stateNode{key: key, row: row}
+		nodes = append(nodes, node)
+		byID[key] = node
+	}
+
+	for _, node := range nodes {
+		if node.row.ParentStateID == nil {
+			continue
+		}
+		parentKey := strings.ToLower(strings.TrimSpace(*node.row.ParentStateID))
+		if parentKey == "" || parentKey == node.key {
+			continue
+		}
+		parent, ok := byID[parentKey]
+		if !ok {
+			continue
+		}
+		node.parent = parent
+		parent.children = append(parent.children, node)
+	}
+
+	roots := make([]*stateNode, 0, len(nodes))
+	for _, node := range nodes {
+		if node.parent == nil {
+			roots = append(roots, node)
+		}
+	}
+
+	visited := make(map[string]bool, len(nodes))
+	var walk func(node *stateNode, ancestorsHasNext []bool, depth int, isLast bool)
+	walk = func(node *stateNode, ancestorsHasNext []bool, depth int, isLast bool) {
+		if node == nil {
+			return
+		}
+		if visited[node.key] {
+			return
+		}
+		visited[node.key] = true
+
+		stateID := formatID(node.row.StateID, longIDs)
+		if depth > 0 {
+			stateID = compactTreePrefix(ancestorsHasNext, isLast) + stateID
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			stateID,
+			formatImageID(node.row.ImageID, longIDs),
+			node.row.PrepareKind,
+			node.row.PrepareArgs,
+			node.row.CreatedAt,
+			optionalInt64(node.row.SizeBytes),
+			strconv.Itoa(node.row.RefCount),
+		)
+
+		childAncestors := ancestorsHasNext
+		if depth > 0 {
+			childAncestors = compactTreeNextAncestors(ancestorsHasNext, isLast)
+		}
+		for i, child := range node.children {
+			childLast := i == len(node.children)-1
+			walk(child, childAncestors, depth+1, childLast)
+		}
+	}
+
+	for _, root := range roots {
+		walk(root, nil, 0, true)
+	}
+	for _, node := range nodes {
+		if visited[node.key] {
+			continue
+		}
+		walk(node, nil, 0, true)
+	}
+
 	_ = tw.Flush()
 }
 
@@ -432,7 +510,7 @@ func printJobsTable(w io.Writer, rows []client.PrepareJobEntry, noHeader bool, l
 			formatID(row.JobID, longIDs),
 			row.Status,
 			row.PrepareKind,
-			row.ImageID,
+			formatImageID(row.ImageID, longIDs),
 			formatBool(row.PlanOnly),
 			optionalString(row.CreatedAt),
 			optionalString(row.StartedAt),
@@ -574,4 +652,52 @@ func formatIDPtr(value *string, longIDs bool) string {
 		return ""
 	}
 	return formatID(*value, longIDs)
+}
+
+// formatImageID shortens digest-based image references in human-readable output.
+// See docs/user-guides/sqlrs-ls.md.
+func formatImageID(value string, longIDs bool) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if longIDs {
+		return value
+	}
+
+	const digestPrefix = "sha256:"
+	if strings.HasPrefix(value, digestPrefix) {
+		digest := strings.TrimSpace(strings.TrimPrefix(value, digestPrefix))
+		if len(digest) >= 12 && isHexString(digest[:12]) {
+			return digest[:12]
+		}
+		return value
+	}
+
+	const atDigestMarker = "@sha256:"
+	if i := strings.Index(value, atDigestMarker); i >= 0 {
+		name := strings.TrimSpace(value[:i])
+		digest := strings.TrimSpace(value[i+len(atDigestMarker):])
+		if name != "" && len(digest) >= 12 && isHexString(digest[:12]) {
+			return name + "@" + digest[:12]
+		}
+	}
+
+	return value
+}
+
+func isHexString(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, ch := range value {
+		switch {
+		case ch >= '0' && ch <= '9':
+		case ch >= 'a' && ch <= 'f':
+		case ch >= 'A' && ch <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
 }

--- a/frontend/cli-go/internal/cli/commands_ls_test.go
+++ b/frontend/cli-go/internal/cli/commands_ls_test.go
@@ -1017,3 +1017,111 @@ func TestRunLsGetInstanceError(t *testing.T) {
 		t.Fatalf("expected error")
 	}
 }
+
+func TestPrintStatesTableCompactTreePrefixes(t *testing.T) {
+	rows := []client.StateEntry{
+		{
+			StateID:     "aaaaaaaaaaaa",
+			ImageID:     "postgres@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			PrepareKind: "psql",
+			PrepareArgs: "-c select 1",
+			CreatedAt:   "2025-01-01T00:00:00Z",
+			RefCount:    1,
+		},
+		{
+			StateID:       "bbbbbbbbbbbb",
+			ParentStateID: strPtr("aaaaaaaaaaaa"),
+			ImageID:       "postgres@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			PrepareKind:   "psql",
+			PrepareArgs:   "-c select 2",
+			CreatedAt:     "2025-01-01T00:00:00Z",
+			RefCount:      1,
+		},
+		{
+			StateID:       "dddddddddddd",
+			ParentStateID: strPtr("bbbbbbbbbbbb"),
+			ImageID:       "postgres@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			PrepareKind:   "psql",
+			PrepareArgs:   "-c select 3",
+			CreatedAt:     "2025-01-01T00:00:00Z",
+			RefCount:      1,
+		},
+		{
+			StateID:       "cccccccccccc",
+			ParentStateID: strPtr("aaaaaaaaaaaa"),
+			ImageID:       "postgres@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			PrepareKind:   "psql",
+			PrepareArgs:   "-c select 4",
+			CreatedAt:     "2025-01-01T00:00:00Z",
+			RefCount:      1,
+		},
+		{
+			StateID:       "eeeeeeeeeeee",
+			ParentStateID: strPtr("cccccccccccc"),
+			ImageID:       "postgres@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+			PrepareKind:   "psql",
+			PrepareArgs:   "-c select 5",
+			CreatedAt:     "2025-01-01T00:00:00Z",
+			RefCount:      1,
+		},
+	}
+
+	var buf bytes.Buffer
+	printStatesTable(&buf, rows, false, false)
+	out := buf.String()
+
+	if !strings.Contains(out, "\n+bbbbbbbbbbbb") {
+		t.Fatalf("expected + prefix for first child, got %q", out)
+	}
+	if !strings.Contains(out, "\n`cccccccccccc") {
+		t.Fatalf("expected ` prefix for last child, got %q", out)
+	}
+	if !strings.Contains(out, "\n|`dddddddddddd") {
+		t.Fatalf("expected |` prefix for grandchild, got %q", out)
+	}
+	if !strings.Contains(out, "\n `eeeeeeeeeeee") {
+		t.Fatalf("expected space-prefixed grandchild, got %q", out)
+	}
+
+	rootPos := strings.Index(out, "\naaaaaaaaaaaa")
+	childPos := strings.Index(out, "\n+bbbbbbbbbbbb")
+	grandChildPos := strings.Index(out, "\n|`dddddddddddd")
+	lastChildPos := strings.Index(out, "\n`cccccccccccc")
+	spaceGrandChildPos := strings.Index(out, "\n `eeeeeeeeeeee")
+	if rootPos == -1 || childPos == -1 || grandChildPos == -1 || lastChildPos == -1 || spaceGrandChildPos == -1 {
+		t.Fatalf("expected all nodes in output, got %q", out)
+	}
+	if !(rootPos < childPos && childPos < grandChildPos && grandChildPos < lastChildPos && lastChildPos < spaceGrandChildPos) {
+		t.Fatalf("expected parent-first ordering, got %q", out)
+	}
+}
+
+func TestPrintLs_ImageIDCompactFormatting(t *testing.T) {
+	image := "postgres@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+	rows := []client.NameEntry{
+		{
+			Name:    "dev",
+			ImageID: image,
+			StateID: "aaaaaaaaaaaa",
+			Status:  "active",
+		},
+	}
+
+	var buf bytes.Buffer
+	printNamesTable(&buf, rows, false, false)
+	out := buf.String()
+	if !strings.Contains(out, "postgres@0123456789ab") {
+		t.Fatalf("expected compact digest image id, got %q", out)
+	}
+
+	buf.Reset()
+	printNamesTable(&buf, rows, false, true)
+	out = buf.String()
+	if !strings.Contains(out, image) {
+		t.Fatalf("expected full image id in --long output, got %q", out)
+	}
+}
+
+func strPtr(value string) *string {
+	return &value
+}

--- a/frontend/cli-go/internal/cli/commands_rm.go
+++ b/frontend/cli-go/internal/cli/commands_rm.go
@@ -190,28 +190,18 @@ func printRootNode(w io.Writer, result client.DeleteResult) {
 		return
 	}
 	printNodeLine(w, result.Root, "", true, result)
-	printNodeChildren(w, result.Root.Children, "", result)
+	printNodeChildren(w, result.Root.Children, nil, result)
 }
 
-func printNodeChildren(w io.Writer, children []client.DeleteNode, prefix string, result client.DeleteResult) {
+func printNodeChildren(w io.Writer, children []client.DeleteNode, ancestorsHasNext []bool, result client.DeleteResult) {
 	for i, child := range children {
 		last := i == len(children)-1
-		linePrefix := prefix
-		if last {
-			linePrefix += "`-- "
-		} else {
-			linePrefix += "|-- "
-		}
+		linePrefix := compactTreePrefix(ancestorsHasNext, last) + " "
 		printNodeLine(w, child, linePrefix, false, result)
 
-		nextPrefix := prefix
-		if last {
-			nextPrefix += "    "
-		} else {
-			nextPrefix += "|   "
-		}
 		if len(child.Children) > 0 {
-			printNodeChildren(w, child.Children, nextPrefix, result)
+			nextAncestors := compactTreeNextAncestors(ancestorsHasNext, last)
+			printNodeChildren(w, child.Children, nextAncestors, result)
 		}
 	}
 }

--- a/frontend/cli-go/internal/cli/commands_rm_test.go
+++ b/frontend/cli-go/internal/cli/commands_rm_test.go
@@ -431,8 +431,14 @@ func TestPrintRmChildPrefixes(t *testing.T) {
 	var buf bytes.Buffer
 	PrintRm(&buf, result)
 	out := buf.String()
-	if !strings.Contains(out, "|--") || !strings.Contains(out, "`--") {
-		t.Fatalf("expected tree prefixes, got %q", out)
+	if !strings.Contains(out, "\n+ instance child-1 deleted") {
+		t.Fatalf("expected + prefix for first child, got %q", out)
+	}
+	if !strings.Contains(out, "\n` instance child-2 deleted") {
+		t.Fatalf("expected ` prefix for last child, got %q", out)
+	}
+	if !strings.Contains(out, "\n|` state grandchild deleted") {
+		t.Fatalf("expected |` prefix for grandchild, got %q", out)
 	}
 	if !strings.Contains(out, "grandchild") {
 		t.Fatalf("expected nested child output, got %q", out)

--- a/frontend/cli-go/internal/cli/commands_status.go
+++ b/frontend/cli-go/internal/cli/commands_status.go
@@ -326,15 +326,11 @@ func runtimeProbeCandidates(mode string) ([]string, string) {
 }
 
 func runtimeModeFromEngineConfig(ctx context.Context, cliClient *client.Client, verbose bool) string {
-	value, err := cliClient.GetConfig(ctx, "container.runtime", true)
+	entry, err := cliClient.GetConfigValue(ctx, "container.runtime", true)
 	if err != nil {
 		if verbose {
 			fmt.Fprintf(os.Stderr, "container runtime mode probe failed: %v\n", err)
 		}
-		return "auto"
-	}
-	entry, ok := value.(client.ConfigValue)
-	if !ok {
 		return "auto"
 	}
 	mode, ok := entry.Value.(string)

--- a/frontend/cli-go/internal/cli/commands_status_test.go
+++ b/frontend/cli-go/internal/cli/commands_status_test.go
@@ -181,6 +181,25 @@ func TestRuntimeModeFromEngineConfig(t *testing.T) {
 	if mode != "podman" {
 		t.Fatalf("expected podman mode, got %q", mode)
 	}
+
+	t.Run("fallback-on-non-string", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/config" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"path":"container.runtime","value":123}`))
+		}))
+		defer server.Close()
+
+		cliClient := client.New(server.URL, client.Options{Timeout: time.Second})
+		mode := runtimeModeFromEngineConfig(context.Background(), cliClient, false)
+		if mode != "auto" {
+			t.Fatalf("expected auto mode, got %q", mode)
+		}
+	})
+
 }
 
 func TestRuntimeModeFromEngineConfigFallbackOnError(t *testing.T) {
@@ -609,4 +628,26 @@ func commandExit(ctx context.Context, code int) *exec.Cmd {
 func runExitStatusError(code int) error {
 	cmd := commandExit(context.Background(), code)
 	return cmd.Run()
+}
+
+func TestFormatContainerRuntimeProbeWarning(t *testing.T) {
+	msg := formatContainerRuntimeProbeWarning("config container.runtime=auto", []string{"docker", "podman"}, nil)
+	if !strings.Contains(msg, "no probe results") {
+		t.Fatalf("expected no probe results message, got %q", msg)
+	}
+
+	msg = formatContainerRuntimeProbeWarning(
+		"config container.runtime=auto",
+		[]string{"docker", "podman"},
+		[]runtimeProbe{
+			{name: "docker", path: "/usr/bin/docker", err: errors.New("boom")},
+			{name: "podman"},
+		},
+	)
+	if !strings.Contains(msg, "docker (/usr/bin/docker)") {
+		t.Fatalf("expected path detail, got %q", msg)
+	}
+	if !strings.Contains(msg, "podman: ready") {
+		t.Fatalf("expected ready detail, got %q", msg)
+	}
 }

--- a/frontend/cli-go/internal/cli/root_more_test.go
+++ b/frontend/cli-go/internal/cli/root_more_test.go
@@ -12,6 +12,22 @@ func TestSplitCommandsNonComposite(t *testing.T) {
 	}
 }
 
+func TestSplitCommandsCompositePrepareRun(t *testing.T) {
+	cmds, err := splitCommands([]string{"prepare:psql", "--image", "img", "run:psql", "--", "-c", "select 1"})
+	if err != nil {
+		t.Fatalf("splitCommands: %v", err)
+	}
+	if len(cmds) != 2 {
+		t.Fatalf("expected 2 commands, got %+v", cmds)
+	}
+	if cmds[0].Name != "prepare:psql" || len(cmds[0].Args) != 2 || cmds[0].Args[0] != "--image" {
+		t.Fatalf("unexpected first command: %+v", cmds[0])
+	}
+	if cmds[1].Name != "run:psql" || len(cmds[1].Args) == 0 || cmds[1].Args[0] != "--" {
+		t.Fatalf("unexpected second command: %+v", cmds[1])
+	}
+}
+
 func TestIsCompositePrepareRunFalse(t *testing.T) {
 	if isCompositePrepareRun([]string{"run:psql", "prepare:psql"}) {
 		t.Fatalf("expected false for non-prepare prefix")
@@ -33,5 +49,12 @@ func TestIsCommandToken(t *testing.T) {
 	}
 	if isCommandToken("unknown") {
 		t.Fatalf("unexpected command token")
+	}
+}
+
+func TestSplitCommandsMissingCommand(t *testing.T) {
+	_, err := splitCommands(nil)
+	if err == nil {
+		t.Fatalf("expected error")
 	}
 }

--- a/frontend/cli-go/internal/cli/tree_prefix.go
+++ b/frontend/cli-go/internal/cli/tree_prefix.go
@@ -1,0 +1,31 @@
+package cli
+
+import "strings"
+
+// compactTreePrefix renders a compact tree branch prefix using one character per depth level.
+// See docs/user-guides/sqlrs-ls.md and docs/user-guides/sqlrs-rm.md.
+
+func compactTreePrefix(ancestorsHasNext []bool, isLast bool) string {
+	var b strings.Builder
+	b.Grow(len(ancestorsHasNext) + 1)
+	for _, hasNext := range ancestorsHasNext {
+		if hasNext {
+			b.WriteByte('|')
+		} else {
+			b.WriteByte(' ')
+		}
+	}
+	if isLast {
+		b.WriteByte('`')
+	} else {
+		b.WriteByte('+')
+	}
+	return b.String()
+}
+
+func compactTreeNextAncestors(ancestorsHasNext []bool, parentIsLast bool) []bool {
+	next := make([]bool, 0, len(ancestorsHasNext)+1)
+	next = append(next, ancestorsHasNext...)
+	next = append(next, !parentIsLast)
+	return next
+}

--- a/frontend/cli-go/internal/client/http_client.go
+++ b/frontend/cli-go/internal/client/http_client.go
@@ -263,6 +263,22 @@ func (c *Client) GetConfig(ctx context.Context, path string, effective bool) (an
 	return out, nil
 }
 
+func (c *Client) GetConfigValue(ctx context.Context, path string, effective bool) (ConfigValue, error) {
+	if strings.TrimSpace(path) == "" {
+		return ConfigValue{}, errors.New("config path is required")
+	}
+	query := url.Values{}
+	addFilter(query, "path", path)
+	if effective {
+		query.Set("effective", "true")
+	}
+	var out ConfigValue
+	if err := c.doJSON(ctx, http.MethodGet, appendQuery("/v1/config", query), true, &out); err != nil {
+		return out, err
+	}
+	return out, nil
+}
+
 func (c *Client) SetConfig(ctx context.Context, req ConfigValue) (ConfigValue, error) {
 	var out ConfigValue
 	body, err := json.Marshal(req)


### PR DESCRIPTION
# Summary
The previous version of `sqlrs ls` command didn't show the state dependencies, and used the full container digests in the IMAGE_ID column.

## Changes

- changed the `ls` command output to show the states hierarchy
- updated the `rm` command output to match the tree formatting in `ls`
- cut off the long SHA-256 digests in IMAGE_ID

## Testing
- [x] `frontend/main` tests
- [x] `backend/*` tests didn't run as no changes to the engine
- [x] Manual testing (optional) - didn't run due to a regresssion blocking the liquibase examples preparation. Will be performed once the issue is fixed. 