### PR TITLE
Bug/state dependencies

### DIFF
--- a/backend/local-engine-go/internal/prepare/components.go
+++ b/backend/local-engine-go/internal/prepare/components.go
@@ -14,7 +14,7 @@ type jobCoordinatorAPI interface {
 type taskExecutorAPI interface {
 	executeStateTask(ctx context.Context, jobID string, prepared preparedRequest, task taskState) (string, *ErrorResponse)
 	executePrepareStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime, task taskState) *ErrorResponse
-	executePsqlStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime) *ErrorResponse
+	executePsqlStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime, task taskState) *ErrorResponse
 	executeLiquibaseStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime, task taskState) *ErrorResponse
 	runLiquibaseUpdateSQL(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime) ([]LiquibaseChangeset, *ErrorResponse)
 	createInstance(ctx context.Context, jobID string, prepared preparedRequest, stateID string) (*Result, *ErrorResponse)
@@ -73,8 +73,8 @@ func (m *PrepareService) executePrepareStep(ctx context.Context, jobID string, p
 	return m.executor.executePrepareStep(ctx, jobID, prepared, rt, task)
 }
 
-func (m *PrepareService) executePsqlStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime) *ErrorResponse {
-	return m.executor.executePsqlStep(ctx, jobID, prepared, rt)
+func (m *PrepareService) executePsqlStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime, task taskState) *ErrorResponse {
+	return m.executor.executePsqlStep(ctx, jobID, prepared, rt, task)
 }
 
 func (m *PrepareService) executeLiquibaseStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime, task taskState) *ErrorResponse {

--- a/backend/local-engine-go/internal/prepare/execution.go
+++ b/backend/local-engine-go/internal/prepare/execution.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -42,6 +43,11 @@ type psqlRunner interface {
 
 type liquibaseRunner interface {
 	Run(ctx context.Context, req LiquibaseRunRequest) (string, error)
+}
+
+var listNetInterfaces = net.Interfaces
+var ifaceAddrs = func(iface net.Interface) ([]net.Addr, error) {
+	return iface.Addrs()
 }
 
 type containerPsqlRunner struct {
@@ -597,7 +603,7 @@ func (e *taskExecutor) executeLiquibaseStep(ctx context.Context, jobID string, p
 		args = relativizeLiquibaseHostFileArgs(args, workDir)
 	}
 	args = applyLiquibaseTaskArgs(args, task)
-	args = prependLiquibaseConnectionArgs(args, rt.instance)
+	args = prependLiquibaseConnectionArgs(args, rt.instance, windowsMode)
 	env, err := mapLiquibaseEnv(prepared.request.LiquibaseEnv, windowsMode)
 	if err != nil {
 		return errorResponse("internal_error", "cannot map liquibase env", err.Error())
@@ -646,10 +652,15 @@ func (e *taskExecutor) executeLiquibaseStep(ctx context.Context, jobID string, p
 	return nil
 }
 
-func prependLiquibaseConnectionArgs(args []string, instance engineRuntime.Instance) []string {
+func prependLiquibaseConnectionArgs(args []string, instance engineRuntime.Instance, windowsMode bool) []string {
 	host := instance.Host
 	if strings.TrimSpace(host) == "" {
 		host = "localhost"
+	}
+	if windowsMode && isWSL() && (host == "127.0.0.1" || strings.EqualFold(host, "localhost")) {
+		if resolved, err := resolveWSLPrimaryIPv4(); err == nil && strings.TrimSpace(resolved) != "" {
+			host = resolved
+		}
 	}
 	port := instance.Port
 	if port == 0 {
@@ -666,6 +677,43 @@ func prependLiquibaseConnectionArgs(args []string, instance engineRuntime.Instan
 	out = append(out, conn...)
 	out = append(out, args...)
 	return out
+}
+
+func resolveWSLPrimaryIPv4() (string, error) {
+	ifaces, err := listNetInterfaces()
+	if err != nil {
+		return "", err
+	}
+	var firstGlobal string
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		addrs, err := ifaceAddrs(iface)
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ipNet, ok := addr.(*net.IPNet)
+			if !ok || ipNet == nil || ipNet.IP == nil {
+				continue
+			}
+			ip := ipNet.IP.To4()
+			if ip == nil || ip.IsLoopback() || ip.IsUnspecified() {
+				continue
+			}
+			if iface.Name == "eth0" {
+				return ip.String(), nil
+			}
+			if firstGlobal == "" {
+				firstGlobal = ip.String()
+			}
+		}
+	}
+	if firstGlobal == "" {
+		return "", fmt.Errorf("no global ipv4")
+	}
+	return firstGlobal, nil
 }
 
 func formatExecLine(execPath string, args []string) string {

--- a/backend/local-engine-go/internal/prepare/execution.go
+++ b/backend/local-engine-go/internal/prepare/execution.go
@@ -187,8 +187,12 @@ func (e *taskExecutor) executeStateTask(ctx context.Context, jobID string, prepa
 	var rt *jobRuntime
 
 	if prepared.request.PrepareKind == "psql" {
+		step, err := psqlStepForPreparedTask(prepared, task.TaskID)
+		if err != nil {
+			return "", errorResponse("internal_error", "cannot resolve psql step", err.Error())
+		}
 		lock := &contentLock{files: map[string]*os.File{}}
-		digest, err := computePsqlContentDigestWithLock(prepared.psqlInputs, prepared.psqlWorkDir, lock)
+		digest, err := computePsqlContentDigestWithLock(step.inputs, prepared.psqlWorkDir, lock)
 		if err != nil {
 			_ = lock.Close()
 			return "", errorResponse("invalid_argument", "cannot compute psql content hash", err.Error())
@@ -484,7 +488,7 @@ func (e *taskExecutor) executeStateTask(ctx context.Context, jobID string, prepa
 func (e *taskExecutor) executePrepareStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime, task taskState) *ErrorResponse {
 	switch prepared.request.PrepareKind {
 	case "psql":
-		return e.executePsqlStep(ctx, jobID, prepared, rt)
+		return e.executePsqlStep(ctx, jobID, prepared, rt, task)
 	case "lb":
 		return e.executeLiquibaseStep(ctx, jobID, prepared, rt, task)
 	default:
@@ -505,9 +509,13 @@ func noSpaceFromErrorResponse(message string, phase string, errResp *ErrorRespon
 	return noSpaceErrorResponse(message, phase, errors.New(errResp.Message))
 }
 
-func (e *taskExecutor) executePsqlStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime) *ErrorResponse {
+func (e *taskExecutor) executePsqlStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime, task taskState) *ErrorResponse {
 	m := e.m
-	psqlArgs, workdir, err := buildPsqlExecArgs(prepared.normalizedArgs, rt.scriptMount)
+	step, err := psqlStepForPreparedTask(prepared, task.TaskID)
+	if err != nil {
+		return errorResponse("internal_error", "cannot resolve psql step", err.Error())
+	}
+	psqlArgs, workdir, err := buildPsqlExecArgs(step.args, rt.scriptMount)
 	if err != nil {
 		return errorResponse("internal_error", "cannot prepare psql arguments", err.Error())
 	}
@@ -523,7 +531,7 @@ func (e *taskExecutor) executePsqlStep(ctx context.Context, jobID string, prepar
 	output, err := m.psql.Run(psqlCtx, rt.instance, PsqlRunRequest{
 		Args:    psqlArgs,
 		Env:     map[string]string{},
-		Stdin:   prepared.request.Stdin,
+		Stdin:   step.stdin,
 		WorkDir: workdir,
 	})
 	if !sinkCalled.Load() && strings.TrimSpace(output) != "" {

--- a/backend/local-engine-go/internal/prepare/execution.go
+++ b/backend/local-engine-go/internal/prepare/execution.go
@@ -208,30 +208,35 @@ func (e *taskExecutor) executeStateTask(ctx context.Context, jobID string, prepa
 	}
 
 	if prepared.request.PrepareKind == "lb" {
-		planned, errResp := e.ensureRuntime(ctx, jobID, prepared, task.Input, runner)
-		if errResp != nil {
-			return "", errResp
+		// Liquibase task hash is precomputed during planning and must remain stable
+		// across execution retries to allow cache hits. Recompute only when missing
+		// to support recovery of legacy queued tasks without persisted hashes.
+		if strings.TrimSpace(taskHash) == "" {
+			planned, errResp := e.ensureRuntime(ctx, jobID, prepared, task.Input, runner)
+			if errResp != nil {
+				return "", errResp
+			}
+			rt = planned
+			lock, errResp := ensureLiquibaseContentLock(prepared, task.ChangesetPath)
+			if errResp != nil {
+				return "", errResp
+			}
+			contentLocker = lock
+			changesets, errResp := e.runLiquibaseUpdateSQL(ctx, jobID, prepared, rt)
+			if errResp != nil {
+				_ = lock.Close()
+				return "", errResp
+			}
+			if len(changesets) == 0 {
+				_ = lock.Close()
+				return "", errorResponse("internal_error", "liquibase returned no pending changesets", "")
+			}
+			parentFingerprintID := ""
+			if task.Input != nil {
+				parentFingerprintID = task.Input.ID
+			}
+			taskHash = liquibaseFingerprint(strings.TrimSpace(parentFingerprintID), []LiquibaseChangeset{changesets[0]})
 		}
-		rt = planned
-		lock, errResp := ensureLiquibaseContentLock(prepared, task.ChangesetPath)
-		if errResp != nil {
-			return "", errResp
-		}
-		contentLocker = lock
-		changesets, errResp := e.runLiquibaseUpdateSQL(ctx, jobID, prepared, rt)
-		if errResp != nil {
-			_ = lock.Close()
-			return "", errResp
-		}
-		if len(changesets) == 0 {
-			_ = lock.Close()
-			return "", errorResponse("internal_error", "liquibase returned no pending changesets", "")
-		}
-		parentFingerprintID := ""
-		if task.Input != nil {
-			parentFingerprintID = task.Input.ID
-		}
-		taskHash = liquibaseFingerprint(strings.TrimSpace(parentFingerprintID), []LiquibaseChangeset{changesets[0]})
 	}
 
 	if contentLocker != nil {
@@ -257,15 +262,6 @@ func (e *taskExecutor) executeStateTask(ctx context.Context, jobID string, prepa
 		outputStateID,
 		cached,
 	)
-	if cached {
-		invalidated, errResp := e.snapshot.invalidateDirtyCachedState(ctx, jobID, prepared, outputStateID)
-		if errResp != nil {
-			return "", errResp
-		}
-		if invalidated {
-			cached = false
-		}
-	}
 	cachedFlag := cached
 	if outputStateID != task.OutputStateID || task.TaskHash != taskHash || (task.Cached == nil || *task.Cached != cachedFlag) {
 		update := queue.TaskUpdate{
@@ -280,52 +276,14 @@ func (e *taskExecutor) executeStateTask(ctx context.Context, jobID string, prepa
 	}
 	if cached {
 		m.logTask(jobID, task.TaskID, "cached output_state=%s", outputStateID)
-		if prepared.request.PrepareKind == "psql" || prepared.request.PrepareKind == "lb" {
-			if runner.getRuntime() != nil {
-				m.cleanupRuntime(context.Background(), runner)
-				rt = nil
-				m.logInfoJob(jobID, "cached runtime released state=%s", outputStateID)
-			}
-			planned, errResp := e.startRuntime(ctx, jobID, prepared, &TaskInput{Kind: "state", ID: outputStateID})
-			if errResp == nil {
-				runner.setRuntime(planned)
-				m.logInfoJob(jobID, "cached runtime started state=%s", outputStateID)
-				return outputStateID, nil
-			}
-			if strings.Contains(errResp.Details, "postmaster.pid") ||
-				strings.Contains(errResp.Message, "dirty") ||
-				strings.Contains(errResp.Details, "PG_VERSION") ||
-				strings.Contains(errResp.Message, "PG_VERSION") ||
-				strings.Contains(errResp.Details, "not initialized") ||
-				strings.Contains(errResp.Message, "not initialized") {
-				invalidated, invalidateResp := e.snapshot.invalidateDirtyCachedState(ctx, jobID, prepared, outputStateID)
-				if invalidateResp != nil {
-					return "", invalidateResp
-				}
-				if !invalidated {
-					m.logInfoJob(jobID, "cached runtime start failed; rebuilding state=%s", outputStateID)
-				}
-				forceRebuild = true
-				cached = false
-				cachedFlag = false
-				if outputStateID != task.OutputStateID || task.TaskHash != taskHash || (task.Cached == nil || *task.Cached != cachedFlag) {
-					update := queue.TaskUpdate{
-						TaskHash:      nullableString(taskHash),
-						OutputStateID: nullableString(outputStateID),
-						Cached:        &cachedFlag,
-					}
-					_ = m.queue.UpdateTask(ctx, jobID, task.TaskID, update)
-					task.OutputStateID = outputStateID
-					task.TaskHash = taskHash
-					task.Cached = &cachedFlag
-				}
-			} else {
-				return "", errResp
-			}
+		// Cached states are trusted after marker/metadata checks above; defer
+		// runtime startup to prepare-instance to avoid per-step container churn.
+		if runner.getRuntime() != nil {
+			m.cleanupRuntime(context.Background(), runner)
+			rt = nil
+			m.logInfoJob(jobID, "cached runtime released state=%s", outputStateID)
 		}
-		if cached {
-			return outputStateID, nil
-		}
+		return outputStateID, nil
 	}
 	if capErr := m.ensureCacheCapacity(ctx, jobID, "prepare_step"); capErr != nil {
 		return "", capErr

--- a/backend/local-engine-go/internal/prepare/execution_capacity_test.go
+++ b/backend/local-engine-go/internal/prepare/execution_capacity_test.go
@@ -85,7 +85,7 @@ func TestExecutePsqlStepMapsNoSpaceOutputToCapacityError(t *testing.T) {
 		normalizedArgs: []string{"-c", "select 1"},
 	}
 
-	errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt)
+	errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt, taskState{})
 	if errResp == nil || errResp.Code != "cache_limit_too_small" {
 		t.Fatalf("expected cache_limit_too_small, got %+v", errResp)
 	}

--- a/backend/local-engine-go/internal/prepare/execution_coverage_extra_test.go
+++ b/backend/local-engine-go/internal/prepare/execution_coverage_extra_test.go
@@ -354,23 +354,23 @@ func TestExecutePsqlStepErrors(t *testing.T) {
 	mgr := newManagerWithDeps(t, &fakeStore{}, newQueueStore(t), &testDeps{psql: &fakePsqlRunner{}})
 	prepared := preparedRequest{normalizedArgs: []string{"-f"}}
 	rt := &jobRuntime{scriptMount: &scriptMount{HostRoot: t.TempDir(), ContainerRoot: containerScriptsRoot}}
-	if errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt); errResp == nil {
+	if errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt, taskState{}); errResp == nil {
 		t.Fatalf("expected args error")
 	}
 	mgr.psql = nil
 	prepared = preparedRequest{normalizedArgs: []string{"-c", "select 1"}}
 	rt = &jobRuntime{}
-	if errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt); errResp == nil {
+	if errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt, taskState{}); errResp == nil {
 		t.Fatalf("expected missing psql runner error")
 	}
 	mgr.psql = &fakePsqlRunner{output: " ", err: errors.New("boom")}
-	if errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt); errResp == nil {
+	if errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt, taskState{}); errResp == nil {
 		t.Fatalf("expected execution error")
 	}
 	cancelCtx, cancel := context.WithCancel(context.Background())
 	cancel()
 	mgr.psql = &fakePsqlRunner{}
-	if errResp := mgr.executePsqlStep(cancelCtx, "job-1", prepared, rt); errResp == nil {
+	if errResp := mgr.executePsqlStep(cancelCtx, "job-1", prepared, rt, taskState{}); errResp == nil {
 		t.Fatalf("expected cancelled error")
 	}
 }
@@ -421,7 +421,7 @@ func TestExecutePsqlStepOutputDetails(t *testing.T) {
 	mgr := newManagerWithDeps(t, &fakeStore{}, newQueueStore(t), &testDeps{psql: psql})
 	prepared := preparedRequest{normalizedArgs: []string{"-c", "select 1"}}
 	rt := &jobRuntime{}
-	errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt)
+	errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt, taskState{})
 	if errResp == nil || !strings.Contains(errResp.Details, "details") {
 		t.Fatalf("expected details from output, got %+v", errResp)
 	}
@@ -443,7 +443,7 @@ func TestExecutePsqlStepContextCancelAfterRun(t *testing.T) {
 	rt := &jobRuntime{}
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	if errResp := mgr.executePsqlStep(ctx, "job-1", prepared, rt); errResp == nil {
+	if errResp := mgr.executePsqlStep(ctx, "job-1", prepared, rt, taskState{}); errResp == nil {
 		t.Fatalf("expected cancelled error")
 	}
 }
@@ -460,7 +460,7 @@ func TestExecutePsqlStepOutputFallback(t *testing.T) {
 	mgr := newManagerWithDeps(t, &fakeStore{}, newQueueStore(t), &testDeps{psql: psql})
 	prepared := preparedRequest{normalizedArgs: []string{"-c", "select 1"}}
 	rt := &jobRuntime{}
-	errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt)
+	errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt, taskState{})
 	if errResp == nil || !strings.Contains(errResp.Details, "boom") {
 		t.Fatalf("expected fallback details, got %+v", errResp)
 	}
@@ -501,7 +501,7 @@ func TestExecutePsqlStepRunsAndLogs(t *testing.T) {
 	mgr := newManagerWithDeps(t, &fakeStore{}, newQueueStore(t), &testDeps{psql: psql})
 	prepared := preparedRequest{normalizedArgs: []string{"-c", "select 1"}}
 	rt := &jobRuntime{}
-	if errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt); errResp != nil {
+	if errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt, taskState{}); errResp != nil {
 		t.Fatalf("executePsqlStep: %+v", errResp)
 	}
 }
@@ -613,7 +613,7 @@ func TestExecutePsqlStepOutputLines(t *testing.T) {
 	mgr := newManagerWithDeps(t, &fakeStore{}, newQueueStore(t), &testDeps{psql: psql})
 	prepared := preparedRequest{normalizedArgs: []string{"-c", "select 1"}}
 	rt := &jobRuntime{}
-	if errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt); errResp != nil {
+	if errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt, taskState{}); errResp != nil {
 		t.Fatalf("executePsqlStep: %+v", errResp)
 	}
 }

--- a/backend/local-engine-go/internal/prepare/execution_more_branches_test.go
+++ b/backend/local-engine-go/internal/prepare/execution_more_branches_test.go
@@ -439,7 +439,7 @@ func TestExecutePsqlStepReturnsCancelledWhenRunFailsAfterCancel(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 		cancel()
 	}()
-	errResp := mgr.executePsqlStep(ctx, "job-1", prepared, rt)
+	errResp := mgr.executePsqlStep(ctx, "job-1", prepared, rt, taskState{})
 	if errResp == nil || errResp.Code != "cancelled" {
 		t.Fatalf("expected cancelled error, got %+v", errResp)
 	}

--- a/backend/local-engine-go/internal/prepare/execution_more_branches_test.go
+++ b/backend/local-engine-go/internal/prepare/execution_more_branches_test.go
@@ -101,7 +101,7 @@ func TestExecuteStateTaskCachedUnknownKindReturnsImmediately(t *testing.T) {
 	}
 }
 
-func TestExecuteStateTaskCachedStateMissingPGVersionInvalidatesAndRebuilds(t *testing.T) {
+func TestExecuteStateTaskCachedStateMissingPGVersionReturnsCachedWithoutInvalidation(t *testing.T) {
 	st := &fakeStore{}
 	mgr := newManagerWithStateFS(t, st, &fakeStateFS{})
 	prepared, err := mgr.prepareRequest(Request{
@@ -138,15 +138,15 @@ func TestExecuteStateTaskCachedStateMissingPGVersionInvalidatesAndRebuilds(t *te
 	if got != outputID {
 		t.Fatalf("expected %q, got %q", outputID, got)
 	}
-	if len(st.deletedStates) == 0 || st.deletedStates[0] != outputID {
-		t.Fatalf("expected cached state invalidation, got %+v", st.deletedStates)
+	if len(st.deletedStates) != 0 {
+		t.Fatalf("expected no cached state invalidation during execute task, got %+v", st.deletedStates)
 	}
-	if _, ok := st.statesByID[outputID]; !ok {
-		t.Fatalf("expected state %q to be recreated", outputID)
+	if len(st.states) != 0 {
+		t.Fatalf("expected no state rebuild for cached state, got %+v", st.states)
 	}
 }
 
-func TestExecuteStateTaskCachedStatePGVersionRuntimeFailureRebuildsWithoutInvalidation(t *testing.T) {
+func TestExecuteStateTaskCachedStatePGVersionReturnsWithoutRuntimeStart(t *testing.T) {
 	mountDir := filepath.Join(t.TempDir(), "runtime-mount")
 	if err := os.MkdirAll(mountDir, 0o700); err != nil {
 		t.Fatalf("mkdir mount dir: %v", err)
@@ -194,15 +194,15 @@ func TestExecuteStateTaskCachedStatePGVersionRuntimeFailureRebuildsWithoutInvali
 	if len(st.deletedStates) != 0 {
 		t.Fatalf("expected no cached state invalidation, got %+v", st.deletedStates)
 	}
-	if len(fs.snapshotCalls) != 1 {
-		t.Fatalf("expected forced rebuild snapshot, got %+v", fs.snapshotCalls)
+	if len(fs.snapshotCalls) != 0 {
+		t.Fatalf("expected no snapshot rebuild for cached state, got %+v", fs.snapshotCalls)
 	}
-	if len(st.states) != 1 {
-		t.Fatalf("expected rebuilt state to be stored, got %+v", st.states)
+	if len(st.states) != 0 {
+		t.Fatalf("expected no state rebuild for cached state, got %+v", st.states)
 	}
 }
 
-func TestExecuteStateTaskCachedStateNonRecoverableStartErrorReturnsOriginal(t *testing.T) {
+func TestExecuteStateTaskCachedStateSkipsRuntimeStartErrorPath(t *testing.T) {
 	fs := &fakeStateFS{cloneErr: errors.New("clone failed")}
 	st := &fakeStore{}
 	mgr := newManagerWithStateFS(t, st, fs)
@@ -236,9 +236,12 @@ func TestExecuteStateTaskCachedStateNonRecoverableStartErrorReturnsOriginal(t *t
 			Input:         &TaskInput{Kind: "image", ID: "image-1"},
 		},
 	}
-	_, errResp := mgr.executeStateTask(context.Background(), "job-1", prepared, task)
-	if errResp == nil || !strings.Contains(errResp.Message, "cannot clone state") {
-		t.Fatalf("expected clone error, got %+v", errResp)
+	got, errResp := mgr.executeStateTask(context.Background(), "job-1", prepared, task)
+	if errResp != nil {
+		t.Fatalf("executeStateTask: %+v", errResp)
+	}
+	if got != outputID {
+		t.Fatalf("expected %q, got %q", outputID, got)
 	}
 }
 
@@ -536,7 +539,7 @@ func (r *failStateRuntimeStart) Start(ctx context.Context, req engineRuntime.Sta
 	return instance, nil
 }
 
-func TestExecuteStateTaskLiquibaseCachedStateRuntimeFailureRebuildsWithFreshRuntime(t *testing.T) {
+func TestExecuteStateTaskLiquibaseCachedStateSkipsIntermediateRuntimeStart(t *testing.T) {
 	fs := &fakeStateFS{}
 	st := &fakeStore{}
 	runtime := &failStateRuntimeStart{}
@@ -608,13 +611,13 @@ func TestExecuteStateTaskLiquibaseCachedStateRuntimeFailureRebuildsWithFreshRunt
 	if got != outputID {
 		t.Fatalf("expected %q, got %q", outputID, got)
 	}
-	if len(runtime.startCalls) != 3 {
-		t.Fatalf("expected 3 runtime starts (image/state/image), got %+v", runtime.startCalls)
+	if len(runtime.startCalls) != 1 {
+		t.Fatalf("expected one runtime start for updateSQL fallback, got %+v", runtime.startCalls)
 	}
-	if !runtime.startCalls[0].AllowInitdb || runtime.startCalls[1].AllowInitdb || !runtime.startCalls[2].AllowInitdb {
-		t.Fatalf("unexpected runtime start sequence: %+v", runtime.startCalls)
+	if !runtime.startCalls[0].AllowInitdb {
+		t.Fatalf("expected planning runtime start from image, got %+v", runtime.startCalls)
 	}
-	if len(st.states) != 1 {
-		t.Fatalf("expected rebuilt state to be stored, got %+v", st.states)
+	if len(st.states) != 0 {
+		t.Fatalf("expected no state rebuild for cached liquibase step, got %+v", st.states)
 	}
 }

--- a/backend/local-engine-go/internal/prepare/liquibase_execution_test.go
+++ b/backend/local-engine-go/internal/prepare/liquibase_execution_test.go
@@ -2,6 +2,7 @@ package prepare
 
 import (
 	"context"
+	"net"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -197,7 +198,7 @@ func TestExecuteLiquibaseStepRunError(t *testing.T) {
 }
 
 func TestPrependLiquibaseConnectionArgs(t *testing.T) {
-	out := prependLiquibaseConnectionArgs([]string{"update"}, engineRuntime.Instance{Host: "host", Port: 5432})
+	out := prependLiquibaseConnectionArgs([]string{"update"}, engineRuntime.Instance{Host: "host", Port: 5432}, false)
 	if len(out) < 3 {
 		t.Fatalf("expected args, got %+v", out)
 	}
@@ -207,8 +208,37 @@ func TestPrependLiquibaseConnectionArgs(t *testing.T) {
 	if out[2] != "update" {
 		t.Fatalf("expected update arg, got %+v", out)
 	}
-	empty := prependLiquibaseConnectionArgs(nil, engineRuntime.Instance{})
+	empty := prependLiquibaseConnectionArgs(nil, engineRuntime.Instance{}, false)
 	if len(empty) != 2 || !strings.HasPrefix(empty[0], "--url=") {
 		t.Fatalf("expected connection args only, got %+v", empty)
+	}
+}
+
+func TestPrependLiquibaseConnectionArgsWSLWindowsModeUsesWSLIPv4(t *testing.T) {
+	setWSLForTest(t, true)
+
+	prevList := listNetInterfaces
+	listNetInterfaces = func() ([]net.Interface, error) {
+		return []net.Interface{
+			{Index: 1, Name: "lo", Flags: net.FlagUp | net.FlagLoopback},
+			{Index: 2, Name: "eth0", Flags: net.FlagUp},
+		}, nil
+	}
+	t.Cleanup(func() { listNetInterfaces = prevList })
+
+	prevAddrs := ifaceAddrs
+	ifaceAddrs = func(iface net.Interface) ([]net.Addr, error) {
+		if iface.Name != "eth0" {
+			return nil, nil
+		}
+		return []net.Addr{
+			&net.IPNet{IP: net.ParseIP("172.28.221.15"), Mask: net.CIDRMask(20, 32)},
+		}, nil
+	}
+	t.Cleanup(func() { ifaceAddrs = prevAddrs })
+
+	out := prependLiquibaseConnectionArgs([]string{"update"}, engineRuntime.Instance{Host: "127.0.0.1", Port: 5432}, true)
+	if len(out) < 1 || !strings.Contains(out[0], "jdbc:postgresql://172.28.221.15:5432/postgres") {
+		t.Fatalf("expected WSL ipv4 in URL, got %+v", out)
 	}
 }

--- a/backend/local-engine-go/internal/prepare/manager.go
+++ b/backend/local-engine-go/internal/prepare/manager.go
@@ -1149,7 +1149,7 @@ func (e *taskExecutor) runLiquibaseUpdateSQL(ctx context.Context, jobID string, 
 		args = relativizeLiquibaseHostFileArgs(args, workDir)
 	}
 	args = replaceLiquibaseCommand(args, "updateSQL")
-	args = prependLiquibaseConnectionArgs(args, rt.instance)
+	args = prependLiquibaseConnectionArgs(args, rt.instance, windowsMode)
 	env, err := mapLiquibaseEnv(prepared.request.LiquibaseEnv, windowsMode)
 	if err != nil {
 		return nil, errorResponse("internal_error", "cannot map liquibase env", err.Error())

--- a/backend/local-engine-go/internal/prepare/manager.go
+++ b/backend/local-engine-go/internal/prepare/manager.go
@@ -667,6 +667,13 @@ func (c *jobCoordinator) loadOrPlanTasks(ctx context.Context, jobID string, prep
 		m.trimCompletedJobs(ctx, prepared)
 		return taskStatesFromPlan(tasks), stateID, nil
 	}
+	replanned, tasks, replannedStateID, errResp := c.replanTasksOnDrift(ctx, jobID, prepared, taskRecords)
+	if errResp != nil {
+		return nil, "", errResp
+	}
+	if replanned {
+		return taskStatesFromPlan(tasks), replannedStateID, nil
+	}
 	states := taskStatesFromRecords(taskRecords)
 	stateID := findOutputStateID(states)
 	for i := range states {
@@ -686,6 +693,102 @@ func (c *jobCoordinator) loadOrPlanTasks(ctx context.Context, jobID string, prep
 		}
 	}
 	return states, stateID, nil
+}
+
+func (c *jobCoordinator) replanTasksOnDrift(ctx context.Context, jobID string, prepared preparedRequest, taskRecords []queue.TaskRecord) (bool, []PlanTask, string, *ErrorResponse) {
+	m := c.m
+	if len(taskRecords) == 0 {
+		return false, nil, "", nil
+	}
+	job, ok, err := m.queue.GetJob(ctx, jobID)
+	if err != nil {
+		return false, nil, "", errorResponse("internal_error", "cannot load job", err.Error())
+	}
+	if !ok {
+		return false, nil, "", errorResponse("internal_error", "cannot load job", jobID)
+	}
+
+	signatureDrift, errResp := m.hasPlanSignatureDrift(prepared, job, taskRecords)
+	if errResp != nil {
+		return false, nil, "", errResp
+	}
+	shapeDrift := hasPsqlExecuteShapeDrift(prepared, taskRecords)
+	if !signatureDrift && !shapeDrift {
+		return false, nil, "", nil
+	}
+
+	tasks, stateID, buildErr := c.buildPlan(ctx, jobID, prepared)
+	if buildErr != nil {
+		return false, nil, "", buildErr
+	}
+	if prepared.request.PrepareKind == "lb" {
+		if errResp := m.updateJobSignatureFromPlan(ctx, jobID, prepared, tasks); errResp != nil {
+			return false, nil, "", errResp
+		}
+	} else {
+		if errResp := m.updateJobSignature(ctx, jobID, prepared); errResp != nil {
+			return false, nil, "", errResp
+		}
+	}
+	records := taskRecordsFromPlan(jobID, tasks)
+	if err := m.queue.ReplaceTasks(ctx, jobID, records); err != nil {
+		return false, nil, "", errorResponse("internal_error", "cannot store tasks", err.Error())
+	}
+	m.logJob(jobID, "replanned tasks due to plan drift signature=%t shape=%t count=%d state_id=%s", signatureDrift, shapeDrift, len(tasks), stateID)
+	return true, tasks, stateID, nil
+}
+
+func (m *PrepareService) hasPlanSignatureDrift(prepared preparedRequest, job queue.JobRecord, taskRecords []queue.TaskRecord) (bool, *ErrorResponse) {
+	storedSignature := strings.TrimSpace(valueOrEmpty(job.Signature))
+	if storedSignature == "" {
+		return false, nil
+	}
+
+	var expectedSignature string
+	var errResp *ErrorResponse
+	if prepared.request.PrepareKind == "lb" {
+		expectedSignature, errResp = m.computeJobSignatureFromPlan(prepared, planTasksFromRecords(taskRecords))
+	} else {
+		expectedSignature, errResp = m.computeJobSignature(prepared)
+	}
+	if errResp != nil {
+		return false, errResp
+	}
+	return storedSignature != expectedSignature, nil
+}
+
+func hasPsqlExecuteShapeDrift(prepared preparedRequest, taskRecords []queue.TaskRecord) bool {
+	if prepared.request.PrepareKind != "psql" {
+		return false
+	}
+	expectedExecTasks := len(prepared.psqlSteps)
+	if expectedExecTasks == 0 {
+		expectedExecTasks = 1
+	}
+	if expectedExecTasks <= 1 {
+		return false
+	}
+	actualExecTasks := 0
+	seen := map[string]bool{}
+	for _, task := range taskRecords {
+		if task.Type != "state_execute" {
+			continue
+		}
+		actualExecTasks++
+		seen[task.TaskID] = true
+	}
+	if actualExecTasks > 0 && actualExecTasks < expectedExecTasks {
+		return true
+	}
+	if actualExecTasks != expectedExecTasks {
+		return false
+	}
+	for i := 0; i < expectedExecTasks; i++ {
+		if !seen[fmt.Sprintf("execute-%d", i)] {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *PrepareService) updateJobSignature(ctx context.Context, jobID string, prepared preparedRequest) *ErrorResponse {
@@ -738,6 +841,7 @@ func (m *PrepareService) computeJobSignatureFromPlan(prepared preparedRequest, t
 	hasher := newStateHasher()
 	hasher.write("image_id", imageID)
 	hasher.write("plan_only", fmt.Sprintf("%t", prepared.request.PlanOnly))
+	hasher.write("engine_version", m.version)
 	for _, task := range tasks {
 		hasher.write("task_id", task.TaskID)
 		hasher.write("task_type", task.Type)

--- a/backend/local-engine-go/internal/prepare/manager.go
+++ b/backend/local-engine-go/internal/prepare/manager.go
@@ -560,6 +560,21 @@ func (c *jobCoordinator) runJob(prepared preparedRequest, jobID string) {
 			_ = m.failJob(jobID, errorResponse("internal_error", "task failed", task.TaskID))
 			return
 		}
+		if task.Type == "state_execute" && task.Cached != nil && *task.Cached && strings.TrimSpace(task.OutputStateID) != "" {
+			cached, err := m.isStateCached(task.OutputStateID)
+			if err != nil {
+				_ = m.failJob(jobID, errorResponse("internal_error", "cannot check state cache", err.Error()))
+				return
+			}
+			if cached {
+				stateID = task.OutputStateID
+				if err := m.updateTaskStatus(ctx, jobID, task.TaskID, StatusSucceeded, nil, strPtr(m.now().UTC().Format(time.RFC3339Nano)), nil); err != nil {
+					_ = m.failJob(jobID, errorResponse("internal_error", "cannot update task status", err.Error()))
+					return
+				}
+				continue
+			}
+		}
 		if err := m.updateTaskStatus(ctx, jobID, task.TaskID, StatusRunning, strPtr(m.now().UTC().Format(time.RFC3339Nano)), nil, nil); err != nil {
 			_ = m.failJob(jobID, errorResponse("internal_error", "cannot update task status", err.Error()))
 			return

--- a/backend/local-engine-go/internal/prepare/manager.go
+++ b/backend/local-engine-go/internal/prepare/manager.go
@@ -97,6 +97,7 @@ type preparedRequest struct {
 	liquibaseMounts      []runtime.Mount
 	resolvedImageID      string
 	psqlInputs           []psqlInput
+	psqlSteps            []psqlStep
 	psqlWorkDir          string
 	liquibaseLockPaths   []string
 	liquibaseSearchPaths []string
@@ -839,6 +840,7 @@ func (m *PrepareService) prepareRequest(req Request) (preparedRequest, error) {
 			argsNormalized: psqlPrepared.argsNormalized,
 			filePaths:      psqlPrepared.filePaths,
 			psqlInputs:     psqlPrepared.inputs,
+			psqlSteps:      psqlPrepared.steps,
 			psqlWorkDir:    psqlPrepared.workDir,
 		}
 	case "lb":
@@ -890,25 +892,21 @@ func (c *jobCoordinator) buildPlan(ctx context.Context, jobID string, prepared p
 
 func (c *jobCoordinator) buildPlanPsql(prepared preparedRequest) ([]PlanTask, string, *ErrorResponse) {
 	m := c.m
-	taskHash, errResp := m.computeTaskHash(prepared)
-	if errResp != nil {
-		return nil, "", errResp
-	}
 	imageID := prepared.effectiveImageID()
 	if strings.TrimSpace(imageID) == "" {
 		return nil, "", errorResponse("internal_error", "resolved image id is required", "")
 	}
-	stateID, errResp := m.computeOutputStateID("image", imageID, taskHash)
-	if errResp != nil {
-		return nil, "", errResp
-	}
-	cached, err := m.isStateCached(stateID)
-	if err != nil {
-		return nil, "", errorResponse("internal_error", "cannot check state cache", err.Error())
-	}
-	cachedFlag := cached
 
-	tasks := make([]PlanTask, 0, 3)
+	steps := prepared.psqlSteps
+	if len(steps) == 0 {
+		steps = []psqlStep{{
+			args:   append([]string{}, prepared.normalizedArgs...),
+			inputs: append([]psqlInput{}, prepared.psqlInputs...),
+			stdin:  prepared.request.Stdin,
+		}}
+	}
+
+	tasks := make([]PlanTask, 0, 3+len(steps))
 	tasks = append(tasks, PlanTask{
 		TaskID:      "plan",
 		Type:        "plan",
@@ -922,28 +920,52 @@ func (c *jobCoordinator) buildPlanPsql(prepared preparedRequest) ([]PlanTask, st
 			ResolvedImageID: imageID,
 		})
 	}
-	tasks = append(tasks,
-		PlanTask{
-			TaskID: "execute-0",
+
+	inputKind := "image"
+	inputID := imageID
+	stateID := ""
+	for i, step := range steps {
+		digest, err := computePsqlContentDigest(step.inputs, prepared.psqlWorkDir)
+		if err != nil {
+			return nil, "", errorResponse("invalid_argument", "cannot compute psql content hash", err.Error())
+		}
+		taskHash := psqlTaskHash(prepared.request.PrepareKind, digest.hash, m.version)
+		outputStateID, errResp := m.computeOutputStateID(inputKind, inputID, taskHash)
+		if errResp != nil {
+			return nil, "", errResp
+		}
+		cached, err := m.isStateCached(outputStateID)
+		if err != nil {
+			return nil, "", errorResponse("internal_error", "cannot check state cache", err.Error())
+		}
+		cachedFlag := cached
+		tasks = append(tasks, PlanTask{
+			TaskID: fmt.Sprintf("execute-%d", i),
 			Type:   "state_execute",
 			Input: &TaskInput{
-				Kind: "image",
-				ID:   imageID,
+				Kind: inputKind,
+				ID:   inputID,
 			},
 			TaskHash:      taskHash,
-			OutputStateID: stateID,
+			OutputStateID: outputStateID,
 			Cached:        &cachedFlag,
+		})
+		inputKind = "state"
+		inputID = outputStateID
+		stateID = outputStateID
+	}
+	if strings.TrimSpace(stateID) == "" {
+		return nil, "", errorResponse("internal_error", "missing output state", "")
+	}
+	tasks = append(tasks, PlanTask{
+		TaskID: "prepare-instance",
+		Type:   "prepare_instance",
+		Input: &TaskInput{
+			Kind: "state",
+			ID:   stateID,
 		},
-		PlanTask{
-			TaskID: "prepare-instance",
-			Type:   "prepare_instance",
-			Input: &TaskInput{
-				Kind: "state",
-				ID:   stateID,
-			},
-			InstanceMode: "ephemeral",
-		},
-	)
+		InstanceMode: "ephemeral",
+	})
 	return tasks, stateID, nil
 }
 

--- a/backend/local-engine-go/internal/prepare/manager_delegation_test.go
+++ b/backend/local-engine-go/internal/prepare/manager_delegation_test.go
@@ -64,7 +64,7 @@ func (s *executorSpy) executePrepareStep(ctx context.Context, jobID string, prep
 	return nil
 }
 
-func (s *executorSpy) executePsqlStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime) *ErrorResponse {
+func (s *executorSpy) executePsqlStep(ctx context.Context, jobID string, prepared preparedRequest, rt *jobRuntime, task taskState) *ErrorResponse {
 	s.executePsqlStepCalled = true
 	return nil
 }
@@ -169,7 +169,7 @@ func TestManagerDelegatesToExecutorAndSnapshot(t *testing.T) {
 	if !executor.executePrepareStepCalled {
 		t.Fatalf("expected executePrepareStep delegation")
 	}
-	if errResp := mgr.executePsqlStep(context.Background(), "job-1", preparedRequest{}, &jobRuntime{}); errResp != nil {
+	if errResp := mgr.executePsqlStep(context.Background(), "job-1", preparedRequest{}, &jobRuntime{}, taskState{}); errResp != nil {
 		t.Fatalf("unexpected executePsqlStep error: %+v", errResp)
 	}
 	if !executor.executePsqlStepCalled {

--- a/backend/local-engine-go/internal/prepare/manager_more_branches_test.go
+++ b/backend/local-engine-go/internal/prepare/manager_more_branches_test.go
@@ -49,6 +49,161 @@ func TestLoadOrPlanTasksRequeuesRunningStateWhenCacheMissing(t *testing.T) {
 	}
 }
 
+func TestLoadOrPlanTasksReplansLegacySingleStepPsqlShape(t *testing.T) {
+	queueStore := newQueueStore(t)
+	req := Request{
+		PrepareKind: "psql",
+		ImageID:     "image-1@sha256:resolved",
+		PsqlArgs:    []string{"-c", "select 1", "-c", "select 2"},
+	}
+	createJobRecord(t, queueStore, "job-1", req, StatusRunning)
+
+	mgr := newManagerWithQueue(t, &fakeStore{statesByID: map[string]store.StateEntry{}}, queueStore)
+	prepared, err := mgr.prepareRequest(req)
+	if err != nil {
+		t.Fatalf("prepareRequest: %v", err)
+	}
+	signature, errResp := mgr.computeJobSignature(prepared)
+	if errResp != nil {
+		t.Fatalf("computeJobSignature: %+v", errResp)
+	}
+	if err := queueStore.UpdateJob(context.Background(), "job-1", queue.JobUpdate{Signature: &signature}); err != nil {
+		t.Fatalf("UpdateJob signature: %v", err)
+	}
+	legacyTaskHash, errResp := mgr.computeTaskHash(prepared)
+	if errResp != nil {
+		t.Fatalf("computeTaskHash: %+v", errResp)
+	}
+	legacyStateID, errResp := mgr.computeOutputStateID("image", prepared.effectiveImageID(), legacyTaskHash)
+	if errResp != nil {
+		t.Fatalf("computeOutputStateID: %+v", errResp)
+	}
+	if err := queueStore.ReplaceTasks(context.Background(), "job-1", []queue.TaskRecord{
+		{
+			JobID:    "job-1",
+			TaskID:   "plan",
+			Position: 0,
+			Type:     "plan",
+			Status:   StatusQueued,
+		},
+		{
+			JobID:         "job-1",
+			TaskID:        "execute-0",
+			Position:      1,
+			Type:          "state_execute",
+			Status:        StatusQueued,
+			InputKind:     strPtr("image"),
+			InputID:       strPtr(prepared.effectiveImageID()),
+			TaskHash:      &legacyTaskHash,
+			OutputStateID: &legacyStateID,
+		},
+		{
+			JobID:       "job-1",
+			TaskID:      "prepare-instance",
+			Position:    2,
+			Type:        "prepare_instance",
+			Status:      StatusQueued,
+			InputKind:   strPtr("state"),
+			InputID:     &legacyStateID,
+			InstanceMode: strPtr("runtime"),
+		},
+	}); err != nil {
+		t.Fatalf("ReplaceTasks legacy plan: %v", err)
+	}
+
+	states, _, errResp := mgr.loadOrPlanTasks(context.Background(), "job-1", prepared)
+	if errResp != nil {
+		t.Fatalf("loadOrPlanTasks: %+v", errResp)
+	}
+	if len(states) != 4 {
+		t.Fatalf("expected re-planned 4 tasks (plan + 2 execute + prepare-instance), got %+v", states)
+	}
+	foundExecute1 := false
+	for _, task := range states {
+		if task.TaskID == "execute-1" {
+			foundExecute1 = true
+			break
+		}
+	}
+	if !foundExecute1 {
+		t.Fatalf("expected execute-1 task after re-plan, got %+v", states)
+	}
+}
+
+func TestLoadOrPlanTasksReplansOnEngineVersionSignatureDrift(t *testing.T) {
+	queueStore := newQueueStore(t)
+	req := Request{
+		PrepareKind: "psql",
+		ImageID:     "image-1@sha256:resolved",
+		PsqlArgs:    []string{"-c", "select 1"},
+	}
+	createJobRecord(t, queueStore, "job-1", req, StatusRunning)
+
+	mgr := newManagerWithQueue(t, &fakeStore{statesByID: map[string]store.StateEntry{}}, queueStore)
+	prepared, err := mgr.prepareRequest(req)
+	if err != nil {
+		t.Fatalf("prepareRequest: %v", err)
+	}
+
+	currentVersion := mgr.version
+	mgr.version = "legacy-v0"
+	legacySignature, errResp := mgr.computeJobSignature(prepared)
+	if errResp != nil {
+		t.Fatalf("legacy computeJobSignature: %+v", errResp)
+	}
+	legacyTasks, _, errResp := mgr.buildPlan(context.Background(), "job-1", prepared)
+	if errResp != nil {
+		t.Fatalf("legacy buildPlan: %+v", errResp)
+	}
+	mgr.version = currentVersion
+
+	if err := queueStore.UpdateJob(context.Background(), "job-1", queue.JobUpdate{Signature: &legacySignature}); err != nil {
+		t.Fatalf("UpdateJob signature: %v", err)
+	}
+	if err := queueStore.ReplaceTasks(context.Background(), "job-1", taskRecordsFromPlan("job-1", legacyTasks)); err != nil {
+		t.Fatalf("ReplaceTasks legacy plan: %v", err)
+	}
+	legacyExecHash := legacyTasks[1].TaskHash
+
+	states, _, errResp := mgr.loadOrPlanTasks(context.Background(), "job-1", prepared)
+	if errResp != nil {
+		t.Fatalf("loadOrPlanTasks: %+v", errResp)
+	}
+	if len(states) != len(legacyTasks) {
+		t.Fatalf("unexpected re-planned task count: got %d want %d", len(states), len(legacyTasks))
+	}
+
+	records, err := queueStore.ListTasks(context.Background(), "job-1")
+	if err != nil {
+		t.Fatalf("ListTasks: %v", err)
+	}
+	var executeHash string
+	for _, record := range records {
+		if record.TaskID == "execute-0" && record.TaskHash != nil {
+			executeHash = *record.TaskHash
+			break
+		}
+	}
+	if strings.TrimSpace(executeHash) == "" {
+		t.Fatalf("expected execute-0 hash after re-plan")
+	}
+	if executeHash == legacyExecHash {
+		t.Fatalf("expected execute-0 hash to change after version drift re-plan")
+	}
+
+	currentSignature, errResp := mgr.computeJobSignature(prepared)
+	if errResp != nil {
+		t.Fatalf("current computeJobSignature: %+v", errResp)
+	}
+	job, ok, err := queueStore.GetJob(context.Background(), "job-1")
+	if err != nil || !ok {
+		t.Fatalf("GetJob: ok=%v err=%v", ok, err)
+	}
+	if strings.TrimSpace(valueOrEmpty(job.Signature)) != currentSignature {
+		t.Fatalf("expected updated signature %s, got %q", currentSignature, valueOrEmpty(job.Signature))
+	}
+}
+
 func TestUpdateJobSignatureReturnsComputeError(t *testing.T) {
 	mgr := newManager(t, &fakeStore{})
 	prepared := preparedRequest{request: Request{PrepareKind: "lb"}}

--- a/backend/local-engine-go/internal/prepare/manager_test.go
+++ b/backend/local-engine-go/internal/prepare/manager_test.go
@@ -2241,7 +2241,7 @@ func TestStartRuntimeFailsWhenRuntimeDirMissingPGVersion(t *testing.T) {
 	}
 }
 
-func TestExecuteStateTaskInvalidatesDirtyCachedState(t *testing.T) {
+func TestExecuteStateTaskDirtyCachedStateReturnsCachedWithoutInvalidation(t *testing.T) {
 	stateStore := &fakeStore{statesByID: map[string]store.StateEntry{}}
 	mgr := newManagerWithStateFS(t, stateStore, &fakeStateFS{})
 
@@ -2279,15 +2279,15 @@ func TestExecuteStateTaskInvalidatesDirtyCachedState(t *testing.T) {
 	if _, errResp := mgr.executeStateTask(context.Background(), "job-1", prepared, task); errResp != nil {
 		t.Fatalf("executeStateTask: %+v", errResp)
 	}
-	if len(stateStore.deletedStates) == 0 || stateStore.deletedStates[0] != outputID {
-		t.Fatalf("expected cached state deletion, got %+v", stateStore.deletedStates)
+	if len(stateStore.deletedStates) != 0 {
+		t.Fatalf("expected no cached state deletion during execute task, got %+v", stateStore.deletedStates)
 	}
-	if len(stateStore.states) == 0 {
-		t.Fatalf("expected state to be rebuilt")
+	if len(stateStore.states) != 0 {
+		t.Fatalf("expected no rebuild for cached state, got %+v", stateStore.states)
 	}
 }
 
-func TestExecuteStateTaskInvalidatesCachedStateMissingPGVersion(t *testing.T) {
+func TestExecuteStateTaskCachedStateMissingPGVersionReturnsCachedWithoutInvalidationManager(t *testing.T) {
 	stateStore := &fakeStore{statesByID: map[string]store.StateEntry{}}
 	mgr := newManagerWithStateFS(t, stateStore, &fakeStateFS{})
 
@@ -2322,11 +2322,11 @@ func TestExecuteStateTaskInvalidatesCachedStateMissingPGVersion(t *testing.T) {
 	if _, errResp := mgr.executeStateTask(context.Background(), "job-1", prepared, task); errResp != nil {
 		t.Fatalf("executeStateTask: %+v", errResp)
 	}
-	if len(stateStore.deletedStates) == 0 || stateStore.deletedStates[0] != outputID {
-		t.Fatalf("expected cached state deletion, got %+v", stateStore.deletedStates)
+	if len(stateStore.deletedStates) != 0 {
+		t.Fatalf("expected no cached state deletion during execute task, got %+v", stateStore.deletedStates)
 	}
-	if len(stateStore.states) == 0 {
-		t.Fatalf("expected state to be rebuilt")
+	if len(stateStore.states) != 0 {
+		t.Fatalf("expected no rebuild for cached state, got %+v", stateStore.states)
 	}
 }
 
@@ -2520,6 +2520,62 @@ func TestExecuteStateTaskLiquibaseRequiresPendingChangesets(t *testing.T) {
 	}
 	if len(liquibase.runs) == 0 {
 		t.Fatalf("expected liquibase planning call")
+	}
+}
+
+func TestExecuteStateTaskLiquibaseUsesPlannedHashForCachedState(t *testing.T) {
+	stateStore := &fakeStore{statesByID: map[string]store.StateEntry{}}
+	liquibase := &fakeLiquibaseRunner{output: ""}
+	mgr := newManagerWithDeps(t, stateStore, newQueueStore(t), &testDeps{
+		runtime:   &fakeRuntime{},
+		liquibase: liquibase,
+	})
+	prepared, err := mgr.prepareRequest(Request{
+		PrepareKind:   "lb",
+		ImageID:       "image-1",
+		LiquibaseArgs: []string{"update"},
+	})
+	if err != nil {
+		t.Fatalf("prepareRequest: %v", err)
+	}
+
+	taskHash := "planned-task-hash"
+	outputID, errResp := mgr.computeOutputStateID("image", "image-1", taskHash)
+	if errResp != nil {
+		t.Fatalf("computeOutputStateID: %+v", errResp)
+	}
+	stateStore.statesByID[outputID] = store.StateEntry{StateID: outputID, ImageID: "image-1"}
+	paths, err := resolveStatePaths(mgr.stateStoreRoot, "image-1", outputID, mgr.statefs)
+	if err != nil {
+		t.Fatalf("resolveStatePaths: %v", err)
+	}
+	if err := os.MkdirAll(paths.stateDir, 0o700); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(paths.stateDir, "PG_VERSION"), []byte("17"), 0o600); err != nil {
+		t.Fatalf("write PG_VERSION: %v", err)
+	}
+
+	task := taskState{
+		PlanTask: PlanTask{
+			TaskID:        "execute-0",
+			Type:          "state_execute",
+			OutputStateID: outputID,
+			TaskHash:      taskHash,
+			Input:         &TaskInput{Kind: "image", ID: "image-1"},
+		},
+		Status: StatusQueued,
+	}
+
+	got, errResp := mgr.executeStateTask(context.Background(), "job-1", prepared, task)
+	if errResp != nil {
+		t.Fatalf("executeStateTask: %+v", errResp)
+	}
+	if got != outputID {
+		t.Fatalf("expected output %q, got %q", outputID, got)
+	}
+	if len(liquibase.runs) != 0 {
+		t.Fatalf("expected no liquibase updateSQL calls for cached task hash, got %+v", liquibase.runs)
 	}
 }
 

--- a/backend/local-engine-go/internal/prepare/psql.go
+++ b/backend/local-engine-go/internal/prepare/psql.go
@@ -10,6 +10,7 @@ type psqlPrepared struct {
 	normalizedArgs []string
 	argsNormalized string
 	inputs         []psqlInput
+	steps          []psqlStep
 	filePaths      []string
 	workDir        string
 }
@@ -86,11 +87,16 @@ func preparePsqlArgs(args []string, stdin *string) (psqlPrepared, error) {
 	if !hasOnErrorStop {
 		normalized = append(normalized, "-v", "ON_ERROR_STOP=1")
 	}
+	steps, err := buildPsqlSteps(normalized, stdin)
+	if err != nil {
+		return psqlPrepared{}, err
+	}
 
 	return psqlPrepared{
 		normalizedArgs: normalized,
 		argsNormalized: strings.Join(normalized, " "),
 		inputs:         inputs,
+		steps:          steps,
 		filePaths:      filePaths,
 		workDir:        workDir,
 	}, nil

--- a/backend/local-engine-go/internal/prepare/psql_multistep_test.go
+++ b/backend/local-engine-go/internal/prepare/psql_multistep_test.go
@@ -1,0 +1,99 @@
+package prepare
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildPlanPsqlCreatesStateChainPerInput(t *testing.T) {
+	dir := t.TempDir()
+	firstPath := filepath.Join(dir, "01-schema.sql")
+	secondPath := filepath.Join(dir, "02-data.sql")
+	thirdPath := filepath.Join(dir, "03-constraints.sql")
+	if err := os.WriteFile(firstPath, []byte("create table test(id int);\n"), 0o600); err != nil {
+		t.Fatalf("write first script: %v", err)
+	}
+	if err := os.WriteFile(secondPath, []byte("insert into test values (1);\n"), 0o600); err != nil {
+		t.Fatalf("write second script: %v", err)
+	}
+	if err := os.WriteFile(thirdPath, []byte("alter table test add primary key (id);\n"), 0o600); err != nil {
+		t.Fatalf("write third script: %v", err)
+	}
+
+	mgr := newManager(t, &fakeStore{})
+	prepared, err := mgr.prepareRequest(Request{
+		PrepareKind: "psql",
+		ImageID:     "image-1@sha256:resolved",
+		PsqlArgs:    []string{"-f", firstPath, "-f", secondPath, "-f", thirdPath},
+	})
+	if err != nil {
+		t.Fatalf("prepareRequest: %v", err)
+	}
+	if errResp := mgr.ensureResolvedImageID(context.Background(), "job-1", &prepared, nil); errResp != nil {
+		t.Fatalf("ensureResolvedImageID: %+v", errResp)
+	}
+
+	tasks, stateID, errResp := mgr.buildPlan(context.Background(), "job-1", prepared)
+	if errResp != nil {
+		t.Fatalf("buildPlan: %+v", errResp)
+	}
+	if len(tasks) != 5 {
+		t.Fatalf("expected 5 tasks (plan + 3 execute + prepare-instance), got %d", len(tasks))
+	}
+	firstExec := tasks[1]
+	secondExec := tasks[2]
+	thirdExec := tasks[3]
+	if firstExec.Type != "state_execute" || secondExec.Type != "state_execute" || thirdExec.Type != "state_execute" {
+		t.Fatalf("expected 3 state_execute tasks, got %+v", tasks)
+	}
+	if firstExec.Input == nil || firstExec.Input.Kind != "image" || firstExec.Input.ID != prepared.effectiveImageID() {
+		t.Fatalf("unexpected first input: %+v", firstExec.Input)
+	}
+	if secondExec.Input == nil || secondExec.Input.Kind != "state" || secondExec.Input.ID != firstExec.OutputStateID {
+		t.Fatalf("unexpected second input: %+v", secondExec.Input)
+	}
+	if thirdExec.Input == nil || thirdExec.Input.Kind != "state" || thirdExec.Input.ID != secondExec.OutputStateID {
+		t.Fatalf("unexpected third input: %+v", thirdExec.Input)
+	}
+	if stateID != thirdExec.OutputStateID {
+		t.Fatalf("expected final state id %s, got %s", thirdExec.OutputStateID, stateID)
+	}
+	if tasks[4].Type != "prepare_instance" || tasks[4].Input == nil || tasks[4].Input.ID != thirdExec.OutputStateID {
+		t.Fatalf("unexpected prepare-instance task: %+v", tasks[4])
+	}
+}
+
+func TestSubmitPsqlExecutesEachInputAsSeparateStep(t *testing.T) {
+	store := &fakeStore{}
+	psql := &fakePsqlRunner{}
+	mgr := newManagerWithDeps(t, store, newQueueStore(t), &testDeps{psql: psql})
+
+	if _, err := mgr.Submit(context.Background(), Request{
+		PrepareKind: "psql",
+		ImageID:     "image-1@sha256:resolved",
+		PsqlArgs:    []string{"-c", "select 1", "-c", "select 2"},
+	}); err != nil {
+		t.Fatalf("Submit: %v", err)
+	}
+
+	if len(psql.runs) != 2 {
+		t.Fatalf("expected 2 psql runs, got %d", len(psql.runs))
+	}
+	if !containsArg(psql.runs[0].Args, "select 1") || containsArg(psql.runs[0].Args, "select 2") {
+		t.Fatalf("expected first run to execute only first command, got %+v", psql.runs[0].Args)
+	}
+	if !containsArg(psql.runs[1].Args, "select 2") || containsArg(psql.runs[1].Args, "select 1") {
+		t.Fatalf("expected second run to execute only second command, got %+v", psql.runs[1].Args)
+	}
+	if len(store.states) != 2 {
+		t.Fatalf("expected 2 persisted states, got %d", len(store.states))
+	}
+	if store.states[0].ParentStateID != nil {
+		t.Fatalf("expected first state to be rooted at image, got parent %+v", store.states[0].ParentStateID)
+	}
+	if store.states[1].ParentStateID == nil || *store.states[1].ParentStateID != store.states[0].StateID {
+		t.Fatalf("expected second state parent to be first state, got %+v", store.states[1].ParentStateID)
+	}
+}

--- a/backend/local-engine-go/internal/prepare/psql_steps.go
+++ b/backend/local-engine-go/internal/prepare/psql_steps.go
@@ -1,0 +1,143 @@
+package prepare
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type psqlStep struct {
+	args   []string
+	inputs []psqlInput
+	stdin  *string
+}
+
+func buildPsqlSteps(args []string, stdin *string) ([]psqlStep, error) {
+	shared := make([]string, 0, len(args))
+	steps := make([]psqlStep, 0, len(args))
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "-c" || arg == "--command":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("missing value for command flag: %s", arg)
+			}
+			cmd := args[i+1]
+			steps = append(steps, psqlStep{
+				args:   append(append([]string{}, shared...), "-c", cmd),
+				inputs: []psqlInput{{kind: "command", value: cmd}},
+			})
+			i++
+		case strings.HasPrefix(arg, "--command="):
+			cmd := strings.TrimPrefix(arg, "--command=")
+			steps = append(steps, psqlStep{
+				args:   append(append([]string{}, shared...), "-c", cmd),
+				inputs: []psqlInput{{kind: "command", value: cmd}},
+			})
+		case strings.HasPrefix(arg, "-c") && len(arg) > 2:
+			cmd := arg[2:]
+			steps = append(steps, psqlStep{
+				args:   append(append([]string{}, shared...), "-c", cmd),
+				inputs: []psqlInput{{kind: "command", value: cmd}},
+			})
+		case arg == "-f" || arg == "--file":
+			if i+1 >= len(args) {
+				return nil, fmt.Errorf("missing value for file flag: %s", arg)
+			}
+			step, err := buildPsqlFileStep(shared, args[i+1], stdin)
+			if err != nil {
+				return nil, err
+			}
+			steps = append(steps, step)
+			i++
+		case strings.HasPrefix(arg, "--file="):
+			value := strings.TrimPrefix(arg, "--file=")
+			if value == "" {
+				return nil, fmt.Errorf("missing value for file flag: %s", arg)
+			}
+			step, err := buildPsqlFileStep(shared, value, stdin)
+			if err != nil {
+				return nil, err
+			}
+			steps = append(steps, step)
+		case strings.HasPrefix(arg, "-f") && len(arg) > 2:
+			value := arg[2:]
+			step, err := buildPsqlFileStep(shared, value, stdin)
+			if err != nil {
+				return nil, err
+			}
+			steps = append(steps, step)
+		default:
+			shared = append(shared, arg)
+		}
+	}
+
+	if len(steps) == 0 {
+		return []psqlStep{{args: append([]string{}, shared...)}}, nil
+	}
+	return steps, nil
+}
+
+func buildPsqlFileStep(shared []string, value string, stdin *string) (psqlStep, error) {
+	if value == "-" {
+		if stdin == nil {
+			return psqlStep{}, fmt.Errorf("stdin is required when using -f -")
+		}
+		return psqlStep{
+			args:   append(append([]string{}, shared...), "-f", "-"),
+			inputs: []psqlInput{{kind: "stdin", value: *stdin}},
+			stdin:  stdin,
+		}, nil
+	}
+	if strings.TrimSpace(value) == "" {
+		return psqlStep{}, fmt.Errorf("file path is empty")
+	}
+	return psqlStep{
+		args:   append(append([]string{}, shared...), "-f", value),
+		inputs: []psqlInput{{kind: "file", value: value}},
+	}, nil
+}
+
+func psqlStepForTask(steps []psqlStep, taskID string) (psqlStep, error) {
+	if len(steps) == 0 {
+		return psqlStep{}, fmt.Errorf("psql steps are required")
+	}
+	index, err := executeTaskIndex(taskID)
+	if err != nil {
+		return psqlStep{}, err
+	}
+	if index < 0 || index >= len(steps) {
+		return psqlStep{}, fmt.Errorf("psql task index out of range: %d", index)
+	}
+	return steps[index], nil
+}
+
+func psqlStepForPreparedTask(prepared preparedRequest, taskID string) (psqlStep, error) {
+	if len(prepared.psqlSteps) == 0 {
+		return psqlStep{
+			args:   append([]string{}, prepared.normalizedArgs...),
+			inputs: append([]psqlInput{}, prepared.psqlInputs...),
+			stdin:  prepared.request.Stdin,
+		}, nil
+	}
+	return psqlStepForTask(prepared.psqlSteps, taskID)
+}
+
+func executeTaskIndex(taskID string) (int, error) {
+	if strings.TrimSpace(taskID) == "" {
+		return 0, nil
+	}
+	if !strings.HasPrefix(taskID, "execute-") {
+		return 0, fmt.Errorf("invalid execute task id: %s", taskID)
+	}
+	raw := strings.TrimPrefix(taskID, "execute-")
+	if strings.TrimSpace(raw) == "" {
+		return 0, fmt.Errorf("invalid execute task id: %s", taskID)
+	}
+	index, err := strconv.Atoi(raw)
+	if err != nil || index < 0 {
+		return 0, fmt.Errorf("invalid execute task id: %s", taskID)
+	}
+	return index, nil
+}

--- a/backend/local-engine-go/internal/prepare/psql_test_helpers.go
+++ b/backend/local-engine-go/internal/prepare/psql_test_helpers.go
@@ -12,3 +12,18 @@ func psqlOutputStateID(t *testing.T, mgr *PrepareService, prepared preparedReque
 	outputID, _ := mgr.computeOutputStateID(input.Kind, input.ID, taskHash)
 	return outputID
 }
+
+func psqlOutputStateIDForStep(t *testing.T, mgr *PrepareService, prepared preparedRequest, input TaskInput, taskID string) string {
+	t.Helper()
+	step, err := psqlStepForTask(prepared.psqlSteps, taskID)
+	if err != nil {
+		t.Fatalf("psqlStepForTask: %v", err)
+	}
+	digest, err := computePsqlContentDigest(step.inputs, prepared.psqlWorkDir)
+	if err != nil {
+		t.Fatalf("computePsqlContentDigest: %v", err)
+	}
+	taskHash := psqlTaskHash(prepared.request.PrepareKind, digest.hash, mgr.version)
+	outputID, _ := mgr.computeOutputStateID(input.Kind, input.ID, taskHash)
+	return outputID
+}

--- a/backend/local-engine-go/internal/prepare/task_executor_test.go
+++ b/backend/local-engine-go/internal/prepare/task_executor_test.go
@@ -2,9 +2,12 @@ package prepare
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"sqlrs/engine/internal/prepare/queue"
+	"sqlrs/engine/internal/store"
 )
 
 func TestTaskExecutorEnsureRuntimeReusesRunnerRuntime(t *testing.T) {
@@ -99,5 +102,84 @@ func TestTaskExecutorExecuteStateTaskUpdatesTaskMetadata(t *testing.T) {
 	}
 	if record.Cached == nil {
 		t.Fatalf("expected cached decision to be stored")
+	}
+}
+
+func TestTaskExecutorExecuteStateTaskCachedChainDoesNotStartRuntime(t *testing.T) {
+	runtime := &fakeRuntime{}
+	stateStore := &fakeStore{}
+	mgr := newManagerWithDeps(t, stateStore, newQueueStore(t), &testDeps{runtime: runtime})
+	workDir := t.TempDir()
+	step1 := filepath.Join(workDir, "step1.sql")
+	step2 := filepath.Join(workDir, "step2.sql")
+	if err := os.WriteFile(step1, []byte("select 1;"), 0o600); err != nil {
+		t.Fatalf("write step1: %v", err)
+	}
+	if err := os.WriteFile(step2, []byte("select 2;"), 0o600); err != nil {
+		t.Fatalf("write step2: %v", err)
+	}
+	prepared, err := mgr.prepareRequest(Request{
+		PrepareKind: "psql",
+		ImageID:     "image-1",
+		PsqlArgs:    []string{"-f", step1, "-f", step2},
+	})
+	if err != nil {
+		t.Fatalf("prepareRequest: %v", err)
+	}
+	input0 := TaskInput{Kind: "image", ID: "image-1"}
+	state1 := psqlOutputStateIDForStep(t, mgr, prepared, input0, "execute-0")
+	input1 := TaskInput{Kind: "state", ID: state1}
+	state2 := psqlOutputStateIDForStep(t, mgr, prepared, input1, "execute-1")
+
+	stateStore.statesByID = map[string]store.StateEntry{
+		state1: {StateID: state1, ImageID: "image-1"},
+		state2: {StateID: state2, ImageID: "image-1"},
+	}
+	for _, stateID := range []string{state1, state2} {
+		paths, err := resolveStatePaths(mgr.stateStoreRoot, "image-1", stateID, mgr.statefs)
+		if err != nil {
+			t.Fatalf("resolveStatePaths(%s): %v", stateID, err)
+		}
+		if err := os.MkdirAll(paths.stateDir, 0o700); err != nil {
+			t.Fatalf("mkdir state dir %s: %v", stateID, err)
+		}
+		if err := os.WriteFile(filepath.Join(paths.stateDir, "PG_VERSION"), []byte("17"), 0o600); err != nil {
+			t.Fatalf("write PG_VERSION %s: %v", stateID, err)
+		}
+	}
+
+	task0 := taskState{PlanTask: PlanTask{
+		TaskID:        "execute-0",
+		Type:          "state_execute",
+		OutputStateID: state1,
+		Input:         &TaskInput{Kind: "image", ID: "image-1"},
+	}}
+	got0, errResp := mgr.executor.executeStateTask(context.Background(), "job-1", prepared, task0)
+	if errResp != nil {
+		t.Fatalf("executeStateTask task0: %+v", errResp)
+	}
+	if got0 != state1 {
+		t.Fatalf("expected %s, got %s", state1, got0)
+	}
+
+	task1 := taskState{PlanTask: PlanTask{
+		TaskID:        "execute-1",
+		Type:          "state_execute",
+		OutputStateID: state2,
+		Input:         &TaskInput{Kind: "state", ID: state1},
+	}}
+	got1, errResp := mgr.executor.executeStateTask(context.Background(), "job-1", prepared, task1)
+	if errResp != nil {
+		t.Fatalf("executeStateTask task1: %+v", errResp)
+	}
+	if got1 != state2 {
+		t.Fatalf("expected %s, got %s", state2, got1)
+	}
+
+	if len(runtime.startCalls) != 0 {
+		t.Fatalf("expected no runtime starts for cached chain, got %+v", runtime.startCalls)
+	}
+	if len(runtime.stopCalls) != 0 {
+		t.Fatalf("expected no runtime stops for cached chain, got %+v", runtime.stopCalls)
 	}
 }

--- a/backend/local-engine-go/internal/runtime/docker.go
+++ b/backend/local-engine-go/internal/runtime/docker.go
@@ -598,7 +598,9 @@ func (r *DockerRuntime) Stop(ctx context.Context, id string) error {
 	if id == "" {
 		return nil
 	}
-	output, err := r.run(ctx, []string{"stop", "-t", "10", id}, nil)
+	// Instances are ephemeral; force-remove is faster than graceful stop and
+	// avoids waiting on PostgreSQL shutdown during cleanup paths.
+	output, err := r.run(ctx, []string{"rm", "-f", id}, nil)
 	if err != nil && isDockerNotFoundOutput(output, err) {
 		return nil
 	}

--- a/backend/local-engine-go/internal/runtime/docker_test.go
+++ b/backend/local-engine-go/internal/runtime/docker_test.go
@@ -776,8 +776,8 @@ func TestDockerRuntimeStopIgnoresMissingContainer(t *testing.T) {
 	if err := rt.Stop(context.Background(), "container-1"); err != nil {
 		t.Fatalf("expected missing container to be ignored, got %v", err)
 	}
-	if len(runner.calls) != 1 || runner.calls[0].args[0] != "stop" {
-		t.Fatalf("expected docker stop call, got %+v", runner.calls)
+	if len(runner.calls) != 1 || runner.calls[0].args[0] != "rm" || !containsFlag(runner.calls[0].args, "-f") {
+		t.Fatalf("expected docker rm -f call, got %+v", runner.calls)
 	}
 }
 

--- a/frontend/cli-go/internal/daemon/orchestrator.go
+++ b/frontend/cli-go/internal/daemon/orchestrator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -18,6 +19,13 @@ import (
 )
 
 var isWindows = runtime.GOOS == "windows"
+
+var cachedEngineStates = struct {
+	mu sync.Mutex
+	m  map[string]EngineState
+}{
+	m: map[string]EngineState{},
+}
 
 type ConnectOptions struct {
 	Endpoint        string
@@ -50,15 +58,39 @@ func ConnectOrStart(ctx context.Context, opts ConnectOptions) (ConnectResult, er
 		return ConnectResult{Endpoint: endpoint}, nil
 	}
 
+	enginePath := filepath.Join(opts.StateDir, "engine.json")
+	if state, ok := loadCachedEngineState(opts); ok {
+		if healthy, ok := tryHealthyState(ctx, state, opts.ClientTimeout, opts.Verbose); ok {
+			return ConnectResult{Endpoint: healthy.Endpoint, AuthToken: healthy.AuthToken, State: healthy}, nil
+		}
+	}
+	logVerbose(opts.Verbose, "checking engine.json at %s", enginePath)
+	if state, ok, _ := loadHealthyStateWithReason(ctx, enginePath, opts.ClientTimeout); ok {
+		if refreshed, authOK := refreshStateOnAuthRejected(ctx, enginePath, state, opts.ClientTimeout, opts.Verbose); authOK {
+			state = refreshed
+		} else {
+			goto LONG_PATH
+		}
+		storeCachedEngineState(opts, state)
+		logVerbose(opts.Verbose, "engine healthy at %s", state.Endpoint)
+		return ConnectResult{Endpoint: state.Endpoint, AuthToken: state.AuthToken, State: state}, nil
+	}
+
+LONG_PATH:
 	if err := ensureWSLStoreMount(ctx, opts); err != nil {
 		return ConnectResult{}, err
 	}
 
-	enginePath := filepath.Join(opts.StateDir, "engine.json")
-	logVerbose(opts.Verbose, "checking engine.json at %s", enginePath)
-	if state, ok := loadHealthyState(ctx, enginePath, opts.ClientTimeout); ok {
-		logVerbose(opts.Verbose, "engine healthy at %s", state.Endpoint)
-		return ConnectResult{Endpoint: state.Endpoint, AuthToken: state.AuthToken, State: state}, nil
+	mustStartDaemon := false
+	// Recheck after WSL mount setup to avoid unnecessary daemon startup.
+	if state, ok, _ := loadHealthyStateWithReason(ctx, enginePath, opts.ClientTimeout); ok {
+		if refreshed, authOK := refreshStateOnAuthRejected(ctx, enginePath, state, opts.ClientTimeout, opts.Verbose); authOK {
+			state = refreshed
+			logVerbose(opts.Verbose, "engine healthy at %s", state.Endpoint)
+			storeCachedEngineState(opts, state)
+			return ConnectResult{Endpoint: state.Endpoint, AuthToken: state.AuthToken, State: state}, nil
+		}
+		mustStartDaemon = true
 	}
 
 	if !opts.Autostart {
@@ -85,11 +117,21 @@ func ConnectOrStart(ctx context.Context, opts ConnectOptions) (ConnectResult, er
 	defer lock.Release()
 
 	logVerbose(opts.Verbose, "acquired engine lock")
-	if state, ok := loadHealthyState(ctx, enginePath, opts.ClientTimeout); ok {
-		logVerbose(opts.Verbose, "engine became healthy while waiting for lock")
-		return ConnectResult{Endpoint: state.Endpoint, AuthToken: state.AuthToken, State: state}, nil
+	if !mustStartDaemon {
+		if state, ok, _ := loadHealthyStateWithReason(ctx, enginePath, opts.ClientTimeout); ok {
+			if refreshed, authOK := refreshStateOnAuthRejected(ctx, enginePath, state, opts.ClientTimeout, opts.Verbose); authOK {
+				state = refreshed
+				logVerbose(opts.Verbose, "engine became healthy while waiting for lock")
+				storeCachedEngineState(opts, state)
+				return ConnectResult{Endpoint: state.Endpoint, AuthToken: state.AuthToken, State: state}, nil
+			}
+			mustStartDaemon = true
+		}
 	}
 
+	if mustStartDaemon {
+		logVerbose(opts.Verbose, "healthy engine rejected auth after refresh; starting new daemon")
+	}
 	logsDir := filepath.Join(opts.StateDir, "logs")
 	if err := util.EnsureDir(logsDir); err != nil {
 		return ConnectResult{}, err
@@ -167,6 +209,7 @@ func ConnectOrStart(ctx context.Context, opts ConnectOptions) (ConnectResult, er
 				tailer.Stop()
 			}
 			logVerbose(opts.Verbose, "engine healthy at %s", state.Endpoint)
+			storeCachedEngineState(opts, state)
 			return ConnectResult{Endpoint: state.Endpoint, AuthToken: state.AuthToken, State: state}, nil
 		} else if opts.Verbose && reason != "" {
 			now := time.Now()
@@ -226,6 +269,95 @@ func loadHealthyStateWithReason(ctx context.Context, enginePath string, timeout 
 		return EngineState{}, false, "engine state is stale"
 	}
 	return state, true, ""
+}
+
+func cacheKey(opts ConnectOptions) string {
+	return filepath.Clean(strings.TrimSpace(opts.StateDir))
+}
+
+func loadCachedEngineState(opts ConnectOptions) (EngineState, bool) {
+	key := cacheKey(opts)
+	if key == "" {
+		return EngineState{}, false
+	}
+	cachedEngineStates.mu.Lock()
+	defer cachedEngineStates.mu.Unlock()
+	state, ok := cachedEngineStates.m[key]
+	return state, ok
+}
+
+func storeCachedEngineState(opts ConnectOptions, state EngineState) {
+	key := cacheKey(opts)
+	if key == "" || strings.TrimSpace(state.Endpoint) == "" {
+		return
+	}
+	cachedEngineStates.mu.Lock()
+	cachedEngineStates.m[key] = state
+	cachedEngineStates.mu.Unlock()
+}
+
+func tryHealthyState(ctx context.Context, state EngineState, timeout time.Duration, verbose bool) (EngineState, bool) {
+	health, err := checkHealth(ctx, state.Endpoint, timeout)
+	if err != nil {
+		return EngineState{}, false
+	}
+	if state.InstanceID != "" && health.InstanceID != "" && state.InstanceID != health.InstanceID {
+		return EngineState{}, false
+	}
+	if ok, _, reason := checkAuthWithToken(ctx, state.Endpoint, state.AuthToken, timeout); ok {
+		logVerbose(verbose, "engine healthy at %s", state.Endpoint)
+		return state, true
+	} else if reason != "" {
+		logVerbose(verbose, "auth probe failed: %s", reason)
+	}
+	return EngineState{}, false
+}
+
+func refreshStateOnAuthRejected(ctx context.Context, enginePath string, state EngineState, timeout time.Duration, verbose bool) (EngineState, bool) {
+	if ok, authRejected, reason := checkAuthWithToken(ctx, state.Endpoint, state.AuthToken, timeout); ok {
+		return state, true
+	} else if !authRejected {
+		logVerbose(verbose, "auth probe failed: %s", reason)
+		return EngineState{}, false
+	}
+	logVerbose(verbose, "auth rejected, re-reading engine.json")
+	refreshed, ok, _ := loadHealthyStateWithReason(ctx, enginePath, timeout)
+	if !ok {
+		return EngineState{}, false
+	}
+	if ok, _, _ := checkAuthWithToken(ctx, refreshed.Endpoint, refreshed.AuthToken, timeout); !ok {
+		return EngineState{}, false
+	}
+	return refreshed, true
+}
+
+func checkAuthWithToken(ctx context.Context, endpoint, token string, timeout time.Duration) (ok bool, authRejected bool, reason string) {
+	if strings.TrimSpace(endpoint) == "" {
+		return false, false, "empty endpoint"
+	}
+	// If auth is not configured, health check is sufficient.
+	if strings.TrimSpace(token) == "" {
+		return true, false, ""
+	}
+	base := strings.TrimRight(strings.TrimSpace(endpoint), "/")
+	if !strings.HasPrefix(base, "http://") && !strings.HasPrefix(base, "https://") {
+		base = "http://" + base
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/v1/prepare-jobs", nil)
+	if err != nil {
+		return false, false, err.Error()
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(token))
+	cli := &http.Client{Timeout: timeout}
+	resp, err := cli.Do(req)
+	if err != nil {
+		return false, false, err.Error()
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		return false, true, resp.Status
+	}
+	return true, false, ""
 }
 
 func formatEngineExit(err error) error {

--- a/frontend/cli-go/internal/daemon/orchestrator_test.go
+++ b/frontend/cli-go/internal/daemon/orchestrator_test.go
@@ -296,6 +296,146 @@ func TestConnectOrStartReturnsHealthyState(t *testing.T) {
 	}
 }
 
+func TestConnectOrStartRefreshesEngineStateOnAuthRejected(t *testing.T) {
+	temp := t.TempDir()
+	statePath := filepath.Join(temp, "engine.json")
+	var mu sync.Mutex
+	updated := false
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/health":
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"ok":true,"instanceId":"inst"}`)
+		case "/v1/prepare-jobs":
+			auth := strings.TrimSpace(r.Header.Get("Authorization"))
+			if auth == "Bearer token-new" {
+				w.Header().Set("Content-Type", "application/json")
+				io.WriteString(w, "[]")
+				return
+			}
+			mu.Lock()
+			if !updated {
+				updated = true
+				_ = WriteEngineState(statePath, EngineState{
+					Endpoint:   server.URL,
+					InstanceID: "inst",
+					AuthToken:  "token-new",
+				})
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusForbidden)
+			return
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	if err := WriteEngineState(statePath, EngineState{
+		Endpoint:   server.URL,
+		InstanceID: "inst",
+		AuthToken:  "token-old",
+	}); err != nil {
+		t.Fatalf("WriteEngineState: %v", err)
+	}
+
+	result, err := ConnectOrStart(context.Background(), ConnectOptions{
+		Endpoint:      "auto",
+		Autostart:     false,
+		StateDir:      temp,
+		ClientTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("ConnectOrStart: %v", err)
+	}
+	if result.AuthToken != "token-new" {
+		t.Fatalf("expected refreshed token, got %+v", result)
+	}
+}
+
+func TestCheckAuthWithTokenAcceptsEndpointWithoutScheme(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/prepare-jobs" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if strings.TrimSpace(r.Header.Get("Authorization")) != "Bearer token" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, "[]")
+	}))
+	defer server.Close()
+
+	endpoint := strings.TrimPrefix(server.URL, "http://")
+	ok, rejected, reason := checkAuthWithToken(context.Background(), endpoint, "token", time.Second)
+	if !ok || rejected {
+		t.Fatalf("expected auth probe success, got ok=%v rejected=%v reason=%q", ok, rejected, reason)
+	}
+}
+
+func TestConnectOrStartUsesCachedStateBeforeEngineJSON(t *testing.T) {
+	temp := t.TempDir()
+	statePath := filepath.Join(temp, "engine.json")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/health":
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, `{"ok":true,"instanceId":"inst"}`)
+		case "/v1/prepare-jobs":
+			if strings.TrimSpace(r.Header.Get("Authorization")) != "Bearer token" {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, "[]")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	if err := WriteEngineState(statePath, EngineState{
+		Endpoint:   strings.TrimPrefix(server.URL, "http://"),
+		InstanceID: "inst",
+		AuthToken:  "token",
+	}); err != nil {
+		t.Fatalf("WriteEngineState: %v", err)
+	}
+
+	first, err := ConnectOrStart(context.Background(), ConnectOptions{
+		Endpoint:      "auto",
+		Autostart:     false,
+		StateDir:      temp,
+		ClientTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("first ConnectOrStart: %v", err)
+	}
+	if strings.TrimSpace(first.Endpoint) == "" {
+		t.Fatalf("expected non-empty endpoint: %+v", first)
+	}
+
+	if err := os.Remove(statePath); err != nil {
+		t.Fatalf("remove engine.json: %v", err)
+	}
+
+	second, err := ConnectOrStart(context.Background(), ConnectOptions{
+		Endpoint:      "auto",
+		Autostart:     false,
+		StateDir:      temp,
+		ClientTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("second ConnectOrStart: %v", err)
+	}
+	if second.Endpoint != first.Endpoint {
+		t.Fatalf("expected cached endpoint %q, got %q", first.Endpoint, second.Endpoint)
+	}
+}
+
 func TestConnectOrStartEnsureDirError(t *testing.T) {
 	temp := t.TempDir()
 	runDir := filepath.Join(temp, "run")


### PR DESCRIPTION
# Summary
Fixed the incorrect state dependency tracking for liquibase, that caused repeated re-preparation of the cached states.

## Changes
- Fixed the LB task cache status validation
- Fixed the container churn by skipping the cached tasks execution
- Fixed the extra validation of the PG_DATA contents between cached tasks execution
- Fixed the psql execution planning so it now respects the built-in commits between the -f commands

## Testing
- [x] `frontend/main` tests
- [x] `backend/*` tests
- [x] Manual testing (optional)
