### PR TITLE
Refactor: canonical alias domain

### DIFF
--- a/docs/adr/2026-04-16-canonical-alias-domain-boundary.md
+++ b/docs/adr/2026-04-16-canonical-alias-domain-boundary.md
@@ -1,0 +1,72 @@
+# 2026-04-16 Canonical Alias Domain Boundary
+
+- Conversation timestamp: 2026-04-16T18:49:28.2119926+07:00
+- GitHub user id: @evilguest
+- Agent name/version: Codex / GPT-5
+- Status: Accepted
+
+## Question discussed
+
+When cleaning up duplicated alias ownership between `frontend/cli-go/internal/app`
+and `frontend/cli-go/internal/alias`, what should be moved first into the alias
+package so that execution and inspection share one canonical alias definition
+model without unnecessarily widening the refactor?
+
+## Alternatives considered
+
+1. Keep the current split and continue letting `internal/app` and
+   `internal/alias` maintain separate prepare/run YAML loaders and schema rules.
+2. Move alias definition loading, normalization, and schema validation into
+   `internal/alias` first, but leave execution-specific path-resolution wrappers
+   in `internal/app` for now.
+3. Move both alias definition loading and all execution-path resolution into one
+   shared `internal/alias` API in the same PR.
+
+## Chosen solution
+
+Adopt option 2.
+
+`PR2` introduces one canonical execution-facing alias definition owner inside
+`internal/alias`.
+
+That owner must provide:
+
+- one shared loaded alias-definition model for prepare and run aliases
+- one shared YAML loader and schema validator used by both execution and
+  inspection
+- filesystem-aware loading so ref-backed prepare alias execution can load alias
+  files from a supplied filesystem context
+
+`internal/app` remains responsible in this PR for:
+
+- alias invocation argument parsing
+- command-specific execution flow
+- any path-resolution wrappers that are still needed to preserve current
+  command-specific user-facing errors
+
+## Brief rationale
+
+The highest-value duplication today is not path derivation itself; it is that
+execution and inspection own separate YAML structs, kind normalization, and
+schema validation rules for the same alias files. Removing that duplication
+first gives `internal/alias` clear domain ownership while keeping the patch
+small enough to avoid accidental CLI-facing regressions in error wording or
+ref-backed execution flow.
+
+Moving full execution-path resolution in the same step would enlarge the change
+surface and conflate two different concerns: canonical alias definition
+ownership and CLI-facing path-selection behavior.
+
+## Related documents
+
+- `docs/architecture/cli-maintainability-refactor.md`
+- `docs/architecture/alias-inspection-component-structure.md`
+- `docs/architecture/alias-create-component-structure.md`
+
+## Contradiction check
+
+No existing ADR was marked obsolete.
+
+This decision narrows the next alias maintainability step without changing the
+accepted file-based alias storage model, alias invocation grammar, or alias
+path-resolution semantics recorded in earlier ADRs.

--- a/docs/architecture/cli-maintainability-refactor.RU.md
+++ b/docs/architecture/cli-maintainability-refactor.RU.md
@@ -113,6 +113,8 @@ feature-by-feature срезов:
 канонического владельца в `internal/alias`, а `internal/app` заставить работать
 с этой доменной моделью вместо прямого чтения YAML.
 
+Статус: реализовано в текущей ветке.
+
 ### 5.3 PR3: cleanup generic discover model
 
 Отделить generic discovery report types от aliases analyzer-а, а затем
@@ -226,3 +228,109 @@ top-level dispatch тестируется без мутации package-level fu
 PR1 не должен opportunistically втягивать работу из PR2-PR4. Если изменение
 нужно только для centralize alias ownership, redesign discover payload-ов или
 слияния plan/prepare pipelines, оно относится к следующему срезу.
+
+## 9. Дизайн PR2
+
+### 9.1 Scope
+
+PR2 по-прежнему намеренно узкий.
+
+Входит:
+
+- один канонический execution-facing owner для alias definition в
+  `internal/alias`;
+- общая YAML loading и schema validation для prepare и run alias-ов;
+- filesystem-aware loading, чтобы ref-backed prepare alias execution использовал
+  тот же loader с переданной файловой системой;
+- интеграция `internal/app` через alias package вместо локальных duplicate YAML
+  struct-ов и loader-ов.
+
+Явно вне scope PR2:
+
+- изменение alias command syntax или invocation grammar;
+- замена alias argument parser-ов в `internal/app`;
+- слияние alias path resolution в один shared execution/inspection API там, где
+  это может поменять текущие command-specific error-ы;
+- redesign payload-а для alias create;
+- cleanup discover model;
+- объединение plan/prepare pipeline.
+
+Смысл PR2 — сначала сделать `internal/alias` единственным владельцем alias
+definition, не расползаясь на все остальные alias-related вопросы.
+
+### 9.2 Целевая форма
+
+`internal/alias` становится владельцем execution-facing alias definition.
+
+Ожидаемые additions:
+
+- `alias.Definition`
+  - общие загруженные alias metadata:
+    - `Class`
+    - `Kind`
+    - `Image`
+    - `Args`
+- один общий loader API, экспортируемый из `internal/alias`, например:
+  - `LoadTarget(target Target) (Definition, error)`
+  - `LoadTargetWithFS(target Target, fs inputset.FileSystem) (Definition, error)`
+
+Правила владения:
+
+- `internal/alias` владеет YAML loading, kind normalization и schema check-ами
+  для execution-facing alias файлов;
+- `internal/app` продолжает владеть command-shape parsing для alias invocation,
+  например для `prepare`, `plan` и `run`;
+- `internal/app` может оставить command-specific path-resolution wrapper-ы в
+  этом PR, если они всё ещё нужны для сохранения текущих user-facing error-ов;
+- `CheckTarget` в `internal/alias` должен переиспользовать тот же shared loader,
+  а не держать отдельные duplicate prepare/run definition struct-ы.
+
+После PR2:
+
+- `internal/app` больше не должен определять duplicate execution-only alias
+  types вроде отдельных YAML struct-ов `prepareAlias` / `runAlias`;
+- `internal/app` больше не должен владеть duplicate функциями
+  `loadPrepareAlias*` / `loadRunAlias`.
+
+### 9.3 Почему path resolution пока остаётся split
+
+`internal/alias` уже владеет generic target resolution для inspection и create,
+но в `internal/app` всё ещё остаются command-specific wrapper-ы для execution,
+потому что текущее public behavior включает command-specific wording ошибок и
+ref-backed filesystem path для prepare alias-ов.
+
+Слияние path resolution и definition loading одним шагом слишком расширит
+рефакторинг и повысит риск случайных CLI-facing regressions. Поэтому PR2
+централизует alias definition сначала, а полное выравнивание execution-path
+resolution остаётся на потом, если оно вообще понадобится.
+
+### 9.4 Критерии успеха
+
+PR2 считается успешным, если:
+
+- в `internal/alias` существует один канонический alias-definition loader;
+- alias inspection и alias execution читают одни и те же prepare/run schema
+  rules;
+- ref-backed prepare alias execution всё ещё умеет загружать alias через
+  supplied filesystem;
+- `internal/app` больше не дублирует YAML execution model для alias файлов;
+- public CLI syntax, output и exit-code behavior не меняются.
+
+## 10. Тест-план для PR2
+
+Второй implementation slice должен добавить или обновить тесты вокруг shared
+alias-definition owner.
+
+Ожидаемые тесты:
+
+1. `TestLoadTargetPrepareDefinition`
+2. `TestLoadTargetRunDefinition`
+3. `TestLoadTargetWithFSSupportsPrepareAliasesInRefContexts`
+4. `TestLoadTargetRejectsInvalidPrepareSchema`
+5. `TestLoadTargetRejectsInvalidRunSchema`
+6. `TestCheckTargetReusesSharedAliasDefinitionLoader`
+7. `TestResolvePrepareAliasWithOptionalRefLoadsDefinitionsViaAliasPackage`
+8. `TestRunAliasExecutionLoadsDefinitionsViaAliasPackage`
+
+Точный split по test files не важен, но PR должен доказать, что prepare/run
+execution и alias inspection больше не держат независимые YAML schema loader-ы.

--- a/docs/architecture/cli-maintainability-refactor.md
+++ b/docs/architecture/cli-maintainability-refactor.md
@@ -113,6 +113,8 @@ Move alias definition loading, normalization, and schema validation behind one
 canonical owner in `internal/alias`, and make `internal/app` consume that
 domain model rather than reading YAML directly.
 
+Status: Implemented in the current branch.
+
 ### 5.3 PR3: generic discover model cleanup
 
 Separate generic discovery report types from the aliases analyzer and then split
@@ -227,3 +229,108 @@ top-level dispatch is testable without mutating package-level function state.
 PR1 should not opportunistically absorb PR2-PR4 work. If a change is only
 needed to centralize alias ownership, redesign discover payloads, or merge
 plan/prepare pipelines, it belongs to a later slice.
+
+## 9. PR2 Design
+
+### 9.1 Scope
+
+PR2 is still intentionally narrow.
+
+Included:
+
+- one canonical execution-facing alias definition model in `internal/alias`;
+- shared YAML loading and schema validation for prepare and run aliases;
+- filesystem-aware loading so ref-backed prepare alias execution can reuse the
+  same loader against a supplied filesystem;
+- `internal/app` integration through the alias package instead of local
+  duplicate YAML structs and loaders.
+
+Explicitly out of scope for PR2:
+
+- changing alias command syntax or invocation grammar;
+- replacing `internal/app` alias argument parsers;
+- merging alias path resolution into one shared execution/inspection API when
+  that would change current command-specific errors;
+- alias create payload redesign;
+- discover model cleanup;
+- plan/prepare pipeline unification.
+
+The point of PR2 is to establish one canonical alias-definition owner first,
+without broadening the patch into every alias-related concern.
+
+### 9.2 Target shape
+
+`internal/alias` becomes the owner of execution-facing alias definitions.
+
+Expected additions:
+
+- `alias.Definition`
+  - shared loaded alias metadata:
+    - `Class`
+    - `Kind`
+    - `Image`
+    - `Args`
+- one shared loader API, exposed from `internal/alias`, for example:
+  - `LoadTarget(target Target) (Definition, error)`
+  - `LoadTargetWithFS(target Target, fs inputset.FileSystem) (Definition, error)`
+
+Ownership rules:
+
+- `internal/alias` owns YAML loading, kind normalization, and schema checks for
+  execution-facing alias files;
+- `internal/app` continues to own command-shape parsing such as `prepare`,
+  `plan`, and `run` alias invocation flags;
+- `internal/app` may keep command-specific path-resolution wrappers in this PR
+  if they are still needed to preserve current user-facing errors;
+- `CheckTarget` in `internal/alias` must reuse the same shared loader instead of
+  maintaining its own duplicate prepare/run definition structs.
+
+After PR2:
+
+- `internal/app` should no longer define duplicate execution-only alias types
+  such as separate `prepareAlias` / `runAlias` YAML payload structs;
+- `internal/app` should no longer own duplicate `loadPrepareAlias*` /
+  `loadRunAlias` functions.
+
+### 9.3 Why path resolution stays split for now
+
+`internal/alias` already owns generic target resolution for inspection and
+creation, but `internal/app` still has command-specific wrappers for execution
+because current public behavior includes command-specific error wording and a
+ref-backed filesystem path for prepare aliases.
+
+Pulling path resolution and domain loading together in one step would enlarge
+the refactor and increase the risk of accidental CLI-facing regressions. PR2
+therefore centralizes alias definitions first and leaves full execution-path
+resolution unification for a later cleanup if it is still needed.
+
+### 9.4 Success criteria
+
+PR2 is successful if:
+
+- one canonical alias-definition loader exists in `internal/alias`;
+- alias inspection and alias execution read the same prepare/run schema rules;
+- ref-backed prepare alias execution can still load aliases through a supplied
+  filesystem;
+- `internal/app` no longer duplicates YAML execution models for alias files;
+- public CLI syntax, output, and exit-code behavior remain unchanged.
+
+## 10. PR2 Test Plan
+
+The second implementation slice should add or update tests around the shared
+alias-definition owner.
+
+Expected tests:
+
+1. `TestLoadTargetPrepareDefinition`
+2. `TestLoadTargetRunDefinition`
+3. `TestLoadTargetWithFSSupportsPrepareAliasesInRefContexts`
+4. `TestLoadTargetRejectsInvalidPrepareSchema`
+5. `TestLoadTargetRejectsInvalidRunSchema`
+6. `TestCheckTargetReusesSharedAliasDefinitionLoader`
+7. `TestResolvePrepareAliasWithOptionalRefLoadsDefinitionsViaAliasPackage`
+8. `TestRunAliasExecutionLoadsDefinitionsViaAliasPackage`
+
+The exact test file split is not important, but the PR should prove that
+prepare/run execution and alias inspection no longer maintain independent YAML
+schema loaders.

--- a/frontend/cli-go/internal/alias/check.go
+++ b/frontend/cli-go/internal/alias/check.go
@@ -11,7 +11,6 @@ import (
 	inputliquibase "github.com/sqlrs/cli/internal/inputset/liquibase"
 	inputpgbench "github.com/sqlrs/cli/internal/inputset/pgbench"
 	inputpsql "github.com/sqlrs/cli/internal/inputset/psql"
-	"gopkg.in/yaml.v3"
 )
 
 // CheckScan validates every selected alias discovered by scan mode.
@@ -84,20 +83,8 @@ func CheckTarget(target Target, workspaceRoot string) (CheckResult, error) {
 	return result, nil
 }
 
-type prepareDefinition struct {
-	Kind  string   `yaml:"kind"`
-	Image string   `yaml:"image"`
-	Args  []string `yaml:"args"`
-}
-
-type runDefinition struct {
-	Kind  string   `yaml:"kind"`
-	Image string   `yaml:"image"`
-	Args  []string `yaml:"args"`
-}
-
 func checkPrepareAlias(path string, workspaceRoot string) (string, []Issue) {
-	def, err := loadPrepareAlias(path)
+	def, err := LoadTarget(Target{Class: ClassPrepare, Path: path})
 	if err != nil {
 		return "", []Issue{{Code: "invalid_prepare_alias", Message: err.Error()}}
 	}
@@ -105,61 +92,11 @@ func checkPrepareAlias(path string, workspaceRoot string) (string, []Issue) {
 }
 
 func checkRunAlias(path string, workspaceRoot string) (string, []Issue) {
-	def, err := loadRunAlias(path)
+	def, err := LoadTarget(Target{Class: ClassRun, Path: path})
 	if err != nil {
 		return "", []Issue{{Code: "invalid_run_alias", Message: err.Error()}}
 	}
 	return def.Kind, append([]Issue{}, validateRunAliasPaths(def.Kind, def.Args, path, workspaceRoot)...)
-}
-
-func loadPrepareAlias(path string) (prepareDefinition, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return prepareDefinition{}, err
-	}
-	var def prepareDefinition
-	if err := yaml.Unmarshal(data, &def); err != nil {
-		return prepareDefinition{}, fmt.Errorf("read prepare alias: %w", err)
-	}
-	def.Kind = strings.ToLower(strings.TrimSpace(def.Kind))
-	switch def.Kind {
-	case "":
-		return prepareDefinition{}, fmt.Errorf("prepare alias kind is required")
-	case "psql", "lb":
-	default:
-		return prepareDefinition{}, fmt.Errorf("unknown prepare alias kind: %s", def.Kind)
-	}
-	if len(def.Args) == 0 {
-		return prepareDefinition{}, fmt.Errorf("prepare alias args are required")
-	}
-	return def, nil
-}
-
-func loadRunAlias(path string) (runDefinition, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return runDefinition{}, err
-	}
-	var def runDefinition
-	if err := yaml.Unmarshal(data, &def); err != nil {
-		return runDefinition{}, fmt.Errorf("read run alias: %w", err)
-	}
-	def.Kind = strings.ToLower(strings.TrimSpace(def.Kind))
-	switch def.Kind {
-	case "":
-		return runDefinition{}, fmt.Errorf("run alias kind is required")
-	default:
-		if !runkind.IsKnown(def.Kind) {
-			return runDefinition{}, fmt.Errorf("unknown run alias kind: %s", def.Kind)
-		}
-	}
-	if strings.TrimSpace(def.Image) != "" {
-		return runDefinition{}, fmt.Errorf("run alias does not support image")
-	}
-	if len(def.Args) == 0 {
-		return runDefinition{}, fmt.Errorf("run alias args are required")
-	}
-	return def, nil
 }
 
 func validatePrepareAliasPaths(kind string, args []string, aliasPath string, workspaceRoot string) []Issue {

--- a/frontend/cli-go/internal/alias/load.go
+++ b/frontend/cli-go/internal/alias/load.go
@@ -1,0 +1,112 @@
+package alias
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sqlrs/cli/internal/cli/runkind"
+	"github.com/sqlrs/cli/internal/inputset"
+	"gopkg.in/yaml.v3"
+)
+
+// LoadTarget loads and validates one execution-facing alias definition using
+// the canonical alias-package schema rules.
+func LoadTarget(target Target) (Definition, error) {
+	return LoadTargetWithFS(target, inputset.OSFileSystem{})
+}
+
+// LoadTargetWithFS loads and validates one execution-facing alias definition
+// against the supplied filesystem so ref-backed execution can reuse the same
+// loader as live-host execution and inspection.
+func LoadTargetWithFS(target Target, fs inputset.FileSystem) (Definition, error) {
+	class := normalizeClass(target.Class)
+	if class == "" {
+		return Definition{}, fmt.Errorf("alias class is required")
+	}
+	switch class {
+	case ClassPrepare:
+		return loadPrepareAliasWithFS(target.Path, fs)
+	case ClassRun:
+		return loadRunAliasWithFS(target.Path, fs)
+	default:
+		return Definition{}, fmt.Errorf("alias class is required")
+	}
+}
+
+func loadPrepareAlias(path string) (Definition, error) {
+	return loadPrepareAliasWithFS(path, inputset.OSFileSystem{})
+}
+
+func loadPrepareAliasWithFS(path string, fs inputset.FileSystem) (Definition, error) {
+	def, err := loadDefinition(path, fs)
+	if err != nil {
+		return Definition{}, err
+	}
+	def.Class = ClassPrepare
+	switch def.Kind {
+	case "":
+		return Definition{}, fmt.Errorf("prepare alias kind is required")
+	case "psql", "lb":
+	default:
+		return Definition{}, fmt.Errorf("unknown prepare alias kind: %s", def.Kind)
+	}
+	if len(def.Args) == 0 {
+		return Definition{}, fmt.Errorf("prepare alias args are required")
+	}
+	return def, nil
+}
+
+func loadRunAlias(path string) (Definition, error) {
+	return loadRunAliasWithFS(path, inputset.OSFileSystem{})
+}
+
+func loadRunAliasWithFS(path string, fs inputset.FileSystem) (Definition, error) {
+	def, err := loadDefinition(path, fs)
+	if err != nil {
+		return Definition{}, err
+	}
+	def.Class = ClassRun
+	switch def.Kind {
+	case "":
+		return Definition{}, fmt.Errorf("run alias kind is required")
+	default:
+		if !runkind.IsKnown(def.Kind) {
+			return Definition{}, fmt.Errorf("unknown run alias kind: %s", def.Kind)
+		}
+	}
+	if strings.TrimSpace(def.Image) != "" {
+		return Definition{}, fmt.Errorf("run alias does not support image")
+	}
+	if len(def.Args) == 0 {
+		return Definition{}, fmt.Errorf("run alias args are required")
+	}
+	return def, nil
+}
+
+func loadDefinition(path string, fs inputset.FileSystem) (Definition, error) {
+	data, err := fs.ReadFile(path)
+	if err != nil {
+		return Definition{}, err
+	}
+	var payload struct {
+		Kind  string   `yaml:"kind"`
+		Image string   `yaml:"image"`
+		Args  []string `yaml:"args"`
+	}
+	if err := yaml.Unmarshal(data, &payload); err != nil {
+		class := classifyPath(path)
+		switch class {
+		case ClassPrepare:
+			return Definition{}, fmt.Errorf("read prepare alias: %w", err)
+		case ClassRun:
+			return Definition{}, fmt.Errorf("read run alias: %w", err)
+		default:
+			return Definition{}, err
+		}
+	}
+	return Definition{
+		Kind:  strings.ToLower(strings.TrimSpace(payload.Kind)),
+		Image: strings.TrimSpace(payload.Image),
+		Args:  payload.Args,
+	}, nil
+}

--- a/frontend/cli-go/internal/alias/load_test.go
+++ b/frontend/cli-go/internal/alias/load_test.go
@@ -1,0 +1,174 @@
+package alias
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sqlrs/cli/internal/inputset"
+	"github.com/sqlrs/cli/internal/pathutil"
+)
+
+func TestLoadTargetPrepareDefinition(t *testing.T) {
+	workspace := t.TempDir()
+	aliasPath := writeAliasFile(t, workspace, "chinook.prep.s9s.yaml", "kind: psql\nimage: postgres:17\nargs:\n  - -f\n  - prepare.sql\n")
+
+	target, err := ResolveTarget(ResolveOptions{
+		WorkspaceRoot: workspace,
+		CWD:           workspace,
+		Ref:           "chinook",
+		Class:         ClassPrepare,
+	})
+	if err != nil {
+		t.Fatalf("ResolveTarget: %v", err)
+	}
+	if !pathutil.SameLocalPath(target.Path, aliasPath) {
+		t.Fatalf("target.Path = %q, want %q", target.Path, aliasPath)
+	}
+
+	def, err := LoadTarget(target)
+	if err != nil {
+		t.Fatalf("LoadTarget: %v", err)
+	}
+	if def.Class != ClassPrepare {
+		t.Fatalf("Class = %q, want %q", def.Class, ClassPrepare)
+	}
+	if def.Kind != "psql" {
+		t.Fatalf("Kind = %q, want %q", def.Kind, "psql")
+	}
+	if def.Image != "postgres:17" {
+		t.Fatalf("Image = %q, want %q", def.Image, "postgres:17")
+	}
+	if got := strings.Join(def.Args, "|"); got != "-f|prepare.sql" {
+		t.Fatalf("Args = %q, want %q", got, "-f|prepare.sql")
+	}
+}
+
+func TestLoadTargetRunDefinition(t *testing.T) {
+	workspace := t.TempDir()
+	aliasPath := writeAliasFile(t, workspace, "smoke.run.s9s.yaml", "kind: pgbench\nargs:\n  - -c\n  - 10\n")
+
+	target, err := ResolveTarget(ResolveOptions{
+		WorkspaceRoot: workspace,
+		CWD:           workspace,
+		Ref:           "smoke",
+		Class:         ClassRun,
+	})
+	if err != nil {
+		t.Fatalf("ResolveTarget: %v", err)
+	}
+	if !pathutil.SameLocalPath(target.Path, aliasPath) {
+		t.Fatalf("target.Path = %q, want %q", target.Path, aliasPath)
+	}
+
+	def, err := LoadTarget(target)
+	if err != nil {
+		t.Fatalf("LoadTarget: %v", err)
+	}
+	if def.Class != ClassRun {
+		t.Fatalf("Class = %q, want %q", def.Class, ClassRun)
+	}
+	if def.Kind != "pgbench" {
+		t.Fatalf("Kind = %q, want %q", def.Kind, "pgbench")
+	}
+	if strings.TrimSpace(def.Image) != "" {
+		t.Fatalf("Image = %q, want empty", def.Image)
+	}
+	if got := strings.Join(def.Args, "|"); got != "-c|10" {
+		t.Fatalf("Args = %q, want %q", got, "-c|10")
+	}
+}
+
+func TestLoadTargetWithFSSupportsPrepareAliasesInRefContexts(t *testing.T) {
+	target := Target{
+		Class: ClassPrepare,
+		Path:  filepath.Join("repo", "examples", "chinook.prep.s9s.yaml"),
+	}
+	fsStub := hookAliasFS{
+		readFile: func(path string) ([]byte, error) {
+			if !pathutil.SameLocalPath(path, target.Path) {
+				t.Fatalf("ReadFile path = %q, want %q", path, target.Path)
+			}
+			return []byte("kind: lb\nimage: image\nargs:\n  - update\n"), nil
+		},
+	}
+
+	def, err := LoadTargetWithFS(target, fsStub)
+	if err != nil {
+		t.Fatalf("LoadTargetWithFS: %v", err)
+	}
+	if def.Class != ClassPrepare || def.Kind != "lb" || def.Image != "image" {
+		t.Fatalf("unexpected definition: %+v", def)
+	}
+	if got := strings.Join(def.Args, "|"); got != "update" {
+		t.Fatalf("Args = %q, want %q", got, "update")
+	}
+}
+
+func TestLoadTargetRejectsInvalidPrepareSchema(t *testing.T) {
+	workspace := t.TempDir()
+	path := writeAliasFile(t, workspace, "broken.prep.s9s.yaml", "kind: flyway\nargs:\n  - migrate\n")
+
+	_, err := LoadTarget(Target{Class: ClassPrepare, Path: path})
+	if err == nil || !strings.Contains(err.Error(), "unknown prepare alias kind") {
+		t.Fatalf("expected invalid prepare schema error, got %v", err)
+	}
+}
+
+func TestLoadTargetRejectsInvalidRunSchema(t *testing.T) {
+	workspace := t.TempDir()
+	path := writeAliasFile(t, workspace, "broken.run.s9s.yaml", "kind: psql\nimage: postgres:17\nargs:\n  - -c\n  - select 1\n")
+
+	_, err := LoadTarget(Target{Class: ClassRun, Path: path})
+	if err == nil || !strings.Contains(err.Error(), "run alias does not support image") {
+		t.Fatalf("expected invalid run schema error, got %v", err)
+	}
+}
+
+func TestCheckTargetReusesSharedAliasDefinitionLoader(t *testing.T) {
+	workspace := t.TempDir()
+	path := writeAliasFile(t, workspace, "broken.run.s9s.yaml", "kind: [\n")
+	target := Target{Class: ClassRun, Path: path}
+
+	_, loadErr := LoadTarget(target)
+	if loadErr == nil {
+		t.Fatal("expected LoadTarget error")
+	}
+
+	result, err := CheckTarget(target, workspace)
+	if err != nil {
+		t.Fatalf("CheckTarget: %v", err)
+	}
+	if result.Valid {
+		t.Fatalf("expected invalid result: %+v", result)
+	}
+	if result.Error != loadErr.Error() {
+		t.Fatalf("CheckTarget error = %q, want %q", result.Error, loadErr.Error())
+	}
+	if len(result.Issues) != 1 || result.Issues[0].Message != loadErr.Error() {
+		t.Fatalf("expected shared loader issue message, got %+v", result.Issues)
+	}
+}
+
+type hookAliasFS struct {
+	readFile func(string) ([]byte, error)
+}
+
+func (h hookAliasFS) Stat(path string) (fs.FileInfo, error) {
+	return os.Stat(path)
+}
+
+func (h hookAliasFS) ReadFile(path string) ([]byte, error) {
+	if h.readFile == nil {
+		return nil, os.ErrNotExist
+	}
+	return h.readFile(path)
+}
+
+func (h hookAliasFS) ReadDir(path string) ([]fs.DirEntry, error) {
+	return os.ReadDir(path)
+}
+
+var _ inputset.FileSystem = hookAliasFS{}

--- a/frontend/cli-go/internal/alias/types.go
+++ b/frontend/cli-go/internal/alias/types.go
@@ -61,6 +61,15 @@ type Target struct {
 	Path  string `json:"-"`
 }
 
+// Definition is the canonical loaded alias model reused by execution and
+// inspection after the CLI maintainability refactor.
+type Definition struct {
+	Class Class    `json:"type"`
+	Kind  string   `json:"kind"`
+	Image string   `json:"image,omitempty"`
+	Args  []string `json:"args"`
+}
+
 // Issue is one static validation finding.
 type Issue struct {
 	Code    string `json:"code"`

--- a/frontend/cli-go/internal/app/alias_domain_test.go
+++ b/frontend/cli-go/internal/app/alias_domain_test.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	aliaspkg "github.com/sqlrs/cli/internal/alias"
+)
+
+func TestResolvePrepareAliasWithOptionalRefLoadsDefinitionsViaAliasPackage(t *testing.T) {
+	workspace := t.TempDir()
+	cwd := filepath.Join(workspace, "examples")
+	if err := os.MkdirAll(cwd, 0o700); err != nil {
+		t.Fatalf("mkdir cwd: %v", err)
+	}
+	aliasPath := writePrepareAliasFile(t, cwd, "chinook.prep.s9s.yaml", "kind: psql\nimage: image\nargs:\n  - -f\n  - prepare.sql\n")
+
+	def, gotPath, ref, err := resolvePrepareAliasWithOptionalRef(workspace, cwd, "chinook", "", "", false)
+	if err != nil {
+		t.Fatalf("resolvePrepareAliasWithOptionalRef: %v", err)
+	}
+	if ref != nil {
+		t.Fatalf("expected nil ref context, got %+v", ref)
+	}
+	if gotPath != aliasPath {
+		t.Fatalf("path = %q, want %q", gotPath, aliasPath)
+	}
+	if def.Class != aliaspkg.ClassPrepare {
+		t.Fatalf("Class = %q, want %q", def.Class, aliaspkg.ClassPrepare)
+	}
+	if def.Kind != "psql" || def.Image != "image" {
+		t.Fatalf("unexpected definition: %+v", def)
+	}
+	if got := strings.Join(def.Args, "|"); got != "-f|prepare.sql" {
+		t.Fatalf("Args = %q, want %q", got, "-f|prepare.sql")
+	}
+}
+
+func TestRunAliasExecutionLoadsDefinitionsViaAliasPackage(t *testing.T) {
+	workspace := t.TempDir()
+	cwd := filepath.Join(workspace, "examples")
+	if err := os.MkdirAll(cwd, 0o700); err != nil {
+		t.Fatalf("mkdir cwd: %v", err)
+	}
+	aliasPath := writeRunAliasFile(t, cwd, "smoke.run.s9s.yaml", "kind: pgbench\nargs:\n  - -c\n  - 10\n")
+
+	def, gotPath, err := resolveRunAliasDefinition(workspace, cwd, "smoke")
+	if err != nil {
+		t.Fatalf("resolveRunAliasDefinition: %v", err)
+	}
+	if gotPath != aliasPath {
+		t.Fatalf("path = %q, want %q", gotPath, aliasPath)
+	}
+	if def.Class != aliaspkg.ClassRun {
+		t.Fatalf("Class = %q, want %q", def.Class, aliaspkg.ClassRun)
+	}
+	if def.Kind != "pgbench" || strings.TrimSpace(def.Image) != "" {
+		t.Fatalf("unexpected definition: %+v", def)
+	}
+	if got := strings.Join(def.Args, "|"); got != "-c|10" {
+		t.Fatalf("Args = %q, want %q", got, "-c|10")
+	}
+}

--- a/frontend/cli-go/internal/app/alias_prepare.go
+++ b/frontend/cli-go/internal/app/alias_prepare.go
@@ -1,21 +1,14 @@
 package app
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
+	aliaspkg "github.com/sqlrs/cli/internal/alias"
 	"github.com/sqlrs/cli/internal/inputset"
-	"gopkg.in/yaml.v3"
 )
 
 const prepareAliasSuffix = ".prep.s9s.yaml"
-
-type prepareAlias struct {
-	Kind  string   `yaml:"kind"`
-	Image string   `yaml:"image"`
-	Args  []string `yaml:"args"`
-}
 
 type prepareAliasInvocation struct {
 	Ref             string
@@ -187,34 +180,7 @@ func resolvePrepareAliasPathWithFS(workspaceRoot string, cwd string, ref string,
 	return resolved, nil
 }
 
-func loadPrepareAlias(path string) (prepareAlias, error) {
-	return loadPrepareAliasWithFS(path, inputset.OSFileSystem{})
-}
-
-func loadPrepareAliasWithFS(path string, fs inputset.FileSystem) (prepareAlias, error) {
-	data, err := fs.ReadFile(path)
-	if err != nil {
-		return prepareAlias{}, err
-	}
-	var alias prepareAlias
-	if err := yaml.Unmarshal(data, &alias); err != nil {
-		return prepareAlias{}, fmt.Errorf("read prepare alias: %w", err)
-	}
-	alias.Kind = strings.ToLower(strings.TrimSpace(alias.Kind))
-	switch alias.Kind {
-	case "":
-		return prepareAlias{}, ExitErrorf(2, "prepare alias kind is required")
-	case "psql", "lb":
-	default:
-		return prepareAlias{}, ExitErrorf(2, "unknown prepare alias kind: %s", alias.Kind)
-	}
-	if len(alias.Args) == 0 {
-		return prepareAlias{}, ExitErrorf(2, "prepare alias args are required")
-	}
-	return alias, nil
-}
-
-func buildPrepareAliasCommandArgs(alias prepareAlias, invocation prepareAliasInvocation) []string {
+func buildPrepareAliasCommandArgs(alias aliaspkg.Definition, invocation prepareAliasInvocation) []string {
 	args := make([]string, 0, len(alias.Args)+3)
 	args = appendRefArgs(args, invocation.GitRef, invocation.RefMode, invocation.RefKeepWorktree)
 	if invocation.WatchSpecified {
@@ -232,7 +198,7 @@ func buildPrepareAliasCommandArgs(alias prepareAlias, invocation prepareAliasInv
 	return args
 }
 
-func buildPlanAliasCommandArgs(alias prepareAlias, invocation planAliasInvocation) []string {
+func buildPlanAliasCommandArgs(alias aliaspkg.Definition, invocation planAliasInvocation) []string {
 	args := make([]string, 0, len(alias.Args)+3)
 	args = appendRefArgs(args, invocation.GitRef, invocation.RefMode, invocation.RefKeepWorktree)
 	if strings.TrimSpace(alias.Image) != "" {

--- a/frontend/cli-go/internal/app/alias_prepare_more_test.go
+++ b/frontend/cli-go/internal/app/alias_prepare_more_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	aliaspkg "github.com/sqlrs/cli/internal/alias"
 )
 
 func TestParsePrepareAliasArgsAdditionalBranches(t *testing.T) {
@@ -235,7 +237,7 @@ func TestResolvePrepareAliasPathAdditionalValidation(t *testing.T) {
 
 func TestLoadPrepareAliasReadAndYAMLErrors(t *testing.T) {
 	t.Run("read error", func(t *testing.T) {
-		_, err := loadPrepareAlias(filepath.Join(t.TempDir(), "missing.prep.s9s.yaml"))
+		_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassPrepare, Path: filepath.Join(t.TempDir(), "missing.prep.s9s.yaml")})
 		if err == nil {
 			t.Fatalf("expected read error")
 		}
@@ -246,7 +248,7 @@ func TestLoadPrepareAliasReadAndYAMLErrors(t *testing.T) {
 
 	t.Run("yaml error", func(t *testing.T) {
 		path := writePrepareAliasFile(t, t.TempDir(), "broken.prep.s9s.yaml", "kind: [\n")
-		_, err := loadPrepareAlias(path)
+		_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassPrepare, Path: path})
 		if err == nil || !strings.Contains(err.Error(), "read prepare alias") {
 			t.Fatalf("expected yaml error, got %v", err)
 		}
@@ -255,7 +257,7 @@ func TestLoadPrepareAliasReadAndYAMLErrors(t *testing.T) {
 
 func TestBuildPrepareAliasCommandArgsWatchAndImage(t *testing.T) {
 	args := buildPrepareAliasCommandArgs(
-		prepareAlias{
+		aliaspkg.Definition{
 			Image: " postgres:17 ",
 			Args:  []string{"-f", "prepare.sql"},
 		},
@@ -271,7 +273,7 @@ func TestBuildPrepareAliasCommandArgsWatchAndImage(t *testing.T) {
 
 func TestBuildPrepareAliasCommandArgsRefOptions(t *testing.T) {
 	args := buildPrepareAliasCommandArgs(
-		prepareAlias{
+		aliaspkg.Definition{
 			Image: " postgres:17 ",
 			Args:  []string{"-f", "prepare.sql"},
 		},
@@ -289,7 +291,7 @@ func TestBuildPrepareAliasCommandArgsRefOptions(t *testing.T) {
 
 func TestBuildPlanAliasCommandArgsRefKeepWorktree(t *testing.T) {
 	args := buildPlanAliasCommandArgs(
-		prepareAlias{
+		aliaspkg.Definition{
 			Image: " postgres:17 ",
 			Args:  []string{"update"},
 		},

--- a/frontend/cli-go/internal/app/alias_prepare_test.go
+++ b/frontend/cli-go/internal/app/alias_prepare_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	aliaspkg "github.com/sqlrs/cli/internal/alias"
 )
 
 func TestResolvePrepareAliasPathFromStem(t *testing.T) {
@@ -93,7 +95,7 @@ func TestResolvePrepareAliasPathRejectsOutsideWorkspace(t *testing.T) {
 func TestLoadPrepareAliasRequiresKind(t *testing.T) {
 	path := writePrepareAliasFile(t, t.TempDir(), "broken.prep.s9s.yaml", "args:\n  - -c\n  - select 1\n")
 
-	_, err := loadPrepareAlias(path)
+	_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassPrepare, Path: path})
 	if err == nil || !strings.Contains(err.Error(), "prepare alias kind is required") {
 		t.Fatalf("expected missing kind error, got %v", err)
 	}
@@ -102,7 +104,7 @@ func TestLoadPrepareAliasRequiresKind(t *testing.T) {
 func TestLoadPrepareAliasRequiresArgs(t *testing.T) {
 	path := writePrepareAliasFile(t, t.TempDir(), "broken.prep.s9s.yaml", "kind: psql\n")
 
-	_, err := loadPrepareAlias(path)
+	_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassPrepare, Path: path})
 	if err == nil || !strings.Contains(err.Error(), "prepare alias args are required") {
 		t.Fatalf("expected missing args error, got %v", err)
 	}
@@ -111,7 +113,7 @@ func TestLoadPrepareAliasRequiresArgs(t *testing.T) {
 func TestLoadPrepareAliasRejectsUnknownKind(t *testing.T) {
 	path := writePrepareAliasFile(t, t.TempDir(), "broken.prep.s9s.yaml", "kind: flyway\nargs:\n  - migrate\n")
 
-	_, err := loadPrepareAlias(path)
+	_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassPrepare, Path: path})
 	if err == nil || !strings.Contains(err.Error(), "unknown prepare alias kind") {
 		t.Fatalf("expected unknown kind error, got %v", err)
 	}
@@ -120,9 +122,9 @@ func TestLoadPrepareAliasRejectsUnknownKind(t *testing.T) {
 func TestLoadPrepareAliasPreservesArgOrder(t *testing.T) {
 	path := writePrepareAliasFile(t, t.TempDir(), "ordered.prep.s9s.yaml", "kind: psql\nargs:\n  - -f\n  - prepare.sql\n  - -v\n  - ON_ERROR_STOP=1\n")
 
-	alias, err := loadPrepareAlias(path)
+	alias, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassPrepare, Path: path})
 	if err != nil {
-		t.Fatalf("loadPrepareAlias: %v", err)
+		t.Fatalf("LoadTarget: %v", err)
 	}
 	got := strings.Join(alias.Args, "|")
 	if want := "-f|prepare.sql|-v|ON_ERROR_STOP=1"; got != want {

--- a/frontend/cli-go/internal/app/alias_run.go
+++ b/frontend/cli-go/internal/app/alias_run.go
@@ -1,22 +1,14 @@
 package app
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/sqlrs/cli/internal/cli/runkind"
-	"gopkg.in/yaml.v3"
+	aliaspkg "github.com/sqlrs/cli/internal/alias"
 )
 
 const runAliasSuffix = ".run.s9s.yaml"
-
-type runAlias struct {
-	Kind  string   `yaml:"kind"`
-	Image string   `yaml:"image"`
-	Args  []string `yaml:"args"`
-}
 
 type runAliasInvocation struct {
 	Ref         string
@@ -113,34 +105,19 @@ func resolveRunAliasPath(workspaceRoot string, cwd string, ref string) (string, 
 	return resolved, nil
 }
 
-func loadRunAlias(path string) (runAlias, error) {
-	data, err := os.ReadFile(path)
+func resolveRunAliasDefinition(workspaceRoot string, cwd string, ref string) (aliaspkg.Definition, string, error) {
+	aliasPath, err := resolveRunAliasPath(workspaceRoot, cwd, ref)
 	if err != nil {
-		return runAlias{}, err
+		return aliaspkg.Definition{}, "", err
 	}
-	var alias runAlias
-	if err := yaml.Unmarshal(data, &alias); err != nil {
-		return runAlias{}, fmt.Errorf("read run alias: %w", err)
+	def, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassRun, Path: aliasPath})
+	if err != nil {
+		return aliaspkg.Definition{}, "", err
 	}
-	alias.Kind = strings.ToLower(strings.TrimSpace(alias.Kind))
-	switch alias.Kind {
-	case "":
-		return runAlias{}, ExitErrorf(2, "run alias kind is required")
-	default:
-		if !runkind.IsKnown(alias.Kind) {
-			return runAlias{}, ExitErrorf(2, "unknown run alias kind: %s", alias.Kind)
-		}
-	}
-	if strings.TrimSpace(alias.Image) != "" {
-		return runAlias{}, ExitErrorf(2, "run alias does not support image")
-	}
-	if len(alias.Args) == 0 {
-		return runAlias{}, ExitErrorf(2, "run alias args are required")
-	}
-	return alias, nil
+	return def, aliasPath, nil
 }
 
-func buildRunAliasCommandArgs(alias runAlias, invocation runAliasInvocation) []string {
+func buildRunAliasCommandArgs(alias aliaspkg.Definition, invocation runAliasInvocation) []string {
 	args := make([]string, 0, len(alias.Args)+2)
 	if strings.TrimSpace(invocation.InstanceRef) != "" {
 		args = append(args, "--instance", strings.TrimSpace(invocation.InstanceRef))

--- a/frontend/cli-go/internal/app/alias_run_more_test.go
+++ b/frontend/cli-go/internal/app/alias_run_more_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	aliaspkg "github.com/sqlrs/cli/internal/alias"
 )
 
 func TestParseRunAliasArgsAdditionalBranches(t *testing.T) {
@@ -109,7 +111,7 @@ func TestResolveRunAliasPathAdditionalValidation(t *testing.T) {
 
 func TestLoadRunAliasReadAndYAMLErrors(t *testing.T) {
 	t.Run("read error", func(t *testing.T) {
-		_, err := loadRunAlias(filepath.Join(t.TempDir(), "missing.run.s9s.yaml"))
+		_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassRun, Path: filepath.Join(t.TempDir(), "missing.run.s9s.yaml")})
 		if err == nil {
 			t.Fatalf("expected read error")
 		}
@@ -120,7 +122,7 @@ func TestLoadRunAliasReadAndYAMLErrors(t *testing.T) {
 
 	t.Run("yaml error", func(t *testing.T) {
 		path := writeRunAliasFile(t, t.TempDir(), "broken.run.s9s.yaml", "kind: [\n")
-		_, err := loadRunAlias(path)
+		_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassRun, Path: path})
 		if err == nil || !strings.Contains(err.Error(), "read run alias") {
 			t.Fatalf("expected yaml error, got %v", err)
 		}

--- a/frontend/cli-go/internal/app/alias_run_test.go
+++ b/frontend/cli-go/internal/app/alias_run_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	aliaspkg "github.com/sqlrs/cli/internal/alias"
 	"github.com/sqlrs/cli/internal/client"
 )
 
@@ -94,7 +95,7 @@ func TestResolveRunAliasPathRejectsOutsideWorkspace(t *testing.T) {
 func TestLoadRunAliasRequiresKind(t *testing.T) {
 	path := writeRunAliasFile(t, t.TempDir(), "broken.run.s9s.yaml", "args:\n  - -c\n  - select 1\n")
 
-	_, err := loadRunAlias(path)
+	_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassRun, Path: path})
 	if err == nil || !strings.Contains(err.Error(), "run alias kind is required") {
 		t.Fatalf("expected missing kind error, got %v", err)
 	}
@@ -103,7 +104,7 @@ func TestLoadRunAliasRequiresKind(t *testing.T) {
 func TestLoadRunAliasRequiresArgs(t *testing.T) {
 	path := writeRunAliasFile(t, t.TempDir(), "broken.run.s9s.yaml", "kind: psql\n")
 
-	_, err := loadRunAlias(path)
+	_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassRun, Path: path})
 	if err == nil || !strings.Contains(err.Error(), "run alias args are required") {
 		t.Fatalf("expected missing args error, got %v", err)
 	}
@@ -112,7 +113,7 @@ func TestLoadRunAliasRequiresArgs(t *testing.T) {
 func TestLoadRunAliasRejectsUnknownKind(t *testing.T) {
 	path := writeRunAliasFile(t, t.TempDir(), "broken.run.s9s.yaml", "kind: unknown\nargs:\n  - -c\n  - select 1\n")
 
-	_, err := loadRunAlias(path)
+	_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassRun, Path: path})
 	if err == nil || !strings.Contains(err.Error(), "unknown run alias kind") {
 		t.Fatalf("expected unknown kind error, got %v", err)
 	}
@@ -121,7 +122,7 @@ func TestLoadRunAliasRejectsUnknownKind(t *testing.T) {
 func TestLoadRunAliasRejectsImageField(t *testing.T) {
 	path := writeRunAliasFile(t, t.TempDir(), "broken.run.s9s.yaml", "kind: psql\nimage: postgres:17\nargs:\n  - -c\n  - select 1\n")
 
-	_, err := loadRunAlias(path)
+	_, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassRun, Path: path})
 	if err == nil || !strings.Contains(err.Error(), "run alias does not support image") {
 		t.Fatalf("expected image-field rejection, got %v", err)
 	}
@@ -130,9 +131,9 @@ func TestLoadRunAliasRejectsImageField(t *testing.T) {
 func TestLoadRunAliasPreservesArgOrder(t *testing.T) {
 	path := writeRunAliasFile(t, t.TempDir(), "ordered.run.s9s.yaml", "kind: pgbench\nargs:\n  - -c\n  - 10\n  - -T\n  - 30\n")
 
-	alias, err := loadRunAlias(path)
+	alias, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassRun, Path: path})
 	if err != nil {
-		t.Fatalf("loadRunAlias: %v", err)
+		t.Fatalf("LoadTarget: %v", err)
 	}
 	if got := strings.Join(alias.Args, "|"); got != "-c|10|-T|30" {
 		t.Fatalf("args = %q, want %q", got, "-c|10|-T|30")

--- a/frontend/cli-go/internal/app/ref_alias.go
+++ b/frontend/cli-go/internal/app/ref_alias.go
@@ -1,33 +1,36 @@
 package app
 
-import "github.com/sqlrs/cli/internal/refctx"
+import (
+	aliaspkg "github.com/sqlrs/cli/internal/alias"
+	"github.com/sqlrs/cli/internal/refctx"
+)
 
-func resolvePrepareAliasWithOptionalRef(workspaceRoot string, cwd string, aliasRef string, gitRef string, refMode string, keepWorktree bool) (prepareAlias, string, *refctx.Context, error) {
+func resolvePrepareAliasWithOptionalRef(workspaceRoot string, cwd string, aliasRef string, gitRef string, refMode string, keepWorktree bool) (aliaspkg.Definition, string, *refctx.Context, error) {
 	if gitRef == "" {
 		aliasPath, err := resolvePrepareAliasPath(workspaceRoot, cwd, aliasRef)
 		if err != nil {
-			return prepareAlias{}, "", nil, err
+			return aliaspkg.Definition{}, "", nil, err
 		}
-		alias, err := loadPrepareAlias(aliasPath)
+		alias, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassPrepare, Path: aliasPath})
 		if err != nil {
-			return prepareAlias{}, "", nil, err
+			return aliaspkg.Definition{}, "", nil, err
 		}
 		return alias, aliasPath, nil, nil
 	}
 
 	ctx, err := refctx.Resolve(workspaceRoot, cwd, gitRef, refMode, keepWorktree)
 	if err != nil {
-		return prepareAlias{}, "", nil, err
+		return aliaspkg.Definition{}, "", nil, err
 	}
 	aliasPath, err := resolvePrepareAliasPathWithFS(ctx.WorkspaceRoot, ctx.BaseDir, aliasRef, ctx.FileSystem)
 	if err != nil {
 		_ = ctx.Cleanup()
-		return prepareAlias{}, "", nil, err
+		return aliaspkg.Definition{}, "", nil, err
 	}
-	alias, err := loadPrepareAliasWithFS(aliasPath, ctx.FileSystem)
+	alias, err := aliaspkg.LoadTargetWithFS(aliaspkg.Target{Class: aliaspkg.ClassPrepare, Path: aliasPath}, ctx.FileSystem)
 	if err != nil {
 		_ = ctx.Cleanup()
-		return prepareAlias{}, "", nil, err
+		return aliaspkg.Definition{}, "", nil, err
 	}
 	return alias, aliasPath, &ctx, nil
 }

--- a/frontend/cli-go/internal/app/runner.go
+++ b/frontend/cli-go/internal/app/runner.go
@@ -353,11 +353,7 @@ func (r runner) run(args []string) error {
 				cli.PrintRunUsage(r.deps.stdout)
 				return nil
 			}
-			aliasPath, err := resolveRunAliasPath(cmdCtx.workspaceRoot, cmdCtx.cwd, invocation.Ref)
-			if err != nil {
-				return err
-			}
-			alias, err := loadRunAlias(aliasPath)
+			alias, aliasPath, err := resolveRunAliasDefinition(cmdCtx.workspaceRoot, cmdCtx.cwd, invocation.Ref)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary
- introduce a canonical execution-facing alias definition model in `internal/alias`
- add shared alias loaders (`LoadTarget`, `LoadTargetWithFS`) for prepare/run YAML loading, kind normalization, and schema validation
- switch `internal/app` alias execution and ref-backed prepare alias loading to consume `alias.Definition` instead of local duplicate YAML structs/loaders
- make `alias check` reuse the same shared loader used by execution
- update the CLI maintainability plan and record the accepted PR2 boundary in ADR

## Testing
- go test ./internal/alias -count=1
- go test ./internal/app -count=1
- go test ./internal/alias ./internal/app -coverprofile=pr2.cover.out -count=1
