### PR TITLE
Refactoring: alias scope separation

### DIFF
--- a/frontend/cli-go/internal/alias/errors.go
+++ b/frontend/cli-go/internal/alias/errors.go
@@ -1,0 +1,17 @@
+package alias
+
+import "fmt"
+
+// UserError marks user-facing alias-definition validation failures so the app
+// layer can preserve historical exit-code behavior while sharing one loader.
+type UserError struct {
+	Message string
+}
+
+func (e *UserError) Error() string {
+	return e.Message
+}
+
+func userErrorf(format string, args ...any) *UserError {
+	return &UserError{Message: fmt.Sprintf(format, args...)}
+}

--- a/frontend/cli-go/internal/alias/load.go
+++ b/frontend/cli-go/internal/alias/load.go
@@ -45,13 +45,13 @@ func loadPrepareAliasWithFS(path string, fs inputset.FileSystem) (Definition, er
 	def.Class = ClassPrepare
 	switch def.Kind {
 	case "":
-		return Definition{}, fmt.Errorf("prepare alias kind is required")
+		return Definition{}, userErrorf("prepare alias kind is required")
 	case "psql", "lb":
 	default:
-		return Definition{}, fmt.Errorf("unknown prepare alias kind: %s", def.Kind)
+		return Definition{}, userErrorf("unknown prepare alias kind: %s", def.Kind)
 	}
 	if len(def.Args) == 0 {
-		return Definition{}, fmt.Errorf("prepare alias args are required")
+		return Definition{}, userErrorf("prepare alias args are required")
 	}
 	return def, nil
 }
@@ -68,17 +68,17 @@ func loadRunAliasWithFS(path string, fs inputset.FileSystem) (Definition, error)
 	def.Class = ClassRun
 	switch def.Kind {
 	case "":
-		return Definition{}, fmt.Errorf("run alias kind is required")
+		return Definition{}, userErrorf("run alias kind is required")
 	default:
 		if !runkind.IsKnown(def.Kind) {
-			return Definition{}, fmt.Errorf("unknown run alias kind: %s", def.Kind)
+			return Definition{}, userErrorf("unknown run alias kind: %s", def.Kind)
 		}
 	}
 	if strings.TrimSpace(def.Image) != "" {
-		return Definition{}, fmt.Errorf("run alias does not support image")
+		return Definition{}, userErrorf("run alias does not support image")
 	}
 	if len(def.Args) == 0 {
-		return Definition{}, fmt.Errorf("run alias args are required")
+		return Definition{}, userErrorf("run alias args are required")
 	}
 	return def, nil
 }

--- a/frontend/cli-go/internal/alias/load.go
+++ b/frontend/cli-go/internal/alias/load.go
@@ -38,7 +38,7 @@ func loadPrepareAlias(path string) (Definition, error) {
 }
 
 func loadPrepareAliasWithFS(path string, fs inputset.FileSystem) (Definition, error) {
-	def, err := loadDefinition(path, fs)
+	def, err := loadDefinition(path, ClassPrepare, fs)
 	if err != nil {
 		return Definition{}, err
 	}
@@ -61,7 +61,7 @@ func loadRunAlias(path string) (Definition, error) {
 }
 
 func loadRunAliasWithFS(path string, fs inputset.FileSystem) (Definition, error) {
-	def, err := loadDefinition(path, fs)
+	def, err := loadDefinition(path, ClassRun, fs)
 	if err != nil {
 		return Definition{}, err
 	}
@@ -83,7 +83,7 @@ func loadRunAliasWithFS(path string, fs inputset.FileSystem) (Definition, error)
 	return def, nil
 }
 
-func loadDefinition(path string, fs inputset.FileSystem) (Definition, error) {
+func loadDefinition(path string, class Class, fs inputset.FileSystem) (Definition, error) {
 	data, err := fs.ReadFile(path)
 	if err != nil {
 		return Definition{}, err
@@ -94,8 +94,7 @@ func loadDefinition(path string, fs inputset.FileSystem) (Definition, error) {
 		Args  []string `yaml:"args"`
 	}
 	if err := yaml.Unmarshal(data, &payload); err != nil {
-		class := classifyPath(path)
-		switch class {
+		switch normalizeClass(class) {
 		case ClassPrepare:
 			return Definition{}, userErrorf("read prepare alias: %v", err)
 		case ClassRun:

--- a/frontend/cli-go/internal/alias/load.go
+++ b/frontend/cli-go/internal/alias/load.go
@@ -97,9 +97,9 @@ func loadDefinition(path string, fs inputset.FileSystem) (Definition, error) {
 		class := classifyPath(path)
 		switch class {
 		case ClassPrepare:
-			return Definition{}, fmt.Errorf("read prepare alias: %w", err)
+			return Definition{}, userErrorf("read prepare alias: %v", err)
 		case ClassRun:
-			return Definition{}, fmt.Errorf("read run alias: %w", err)
+			return Definition{}, userErrorf("read run alias: %v", err)
 		default:
 			return Definition{}, err
 		}

--- a/frontend/cli-go/internal/alias/load_test.go
+++ b/frontend/cli-go/internal/alias/load_test.go
@@ -136,6 +136,44 @@ func TestLoadTargetRejectsInvalidRunSchema(t *testing.T) {
 	}
 }
 
+func TestLoadTargetTreatsMalformedYAMLAsUserError(t *testing.T) {
+	tests := []struct {
+		name  string
+		class Class
+		file  string
+		want  string
+	}{
+		{
+			name:  "prepare",
+			class: ClassPrepare,
+			file:  "broken.prep.s9s.yaml",
+			want:  "read prepare alias",
+		},
+		{
+			name:  "run",
+			class: ClassRun,
+			file:  "broken.run.s9s.yaml",
+			want:  "read run alias",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			path := writeAliasFile(t, workspace, tc.file, "kind: [\n")
+
+			_, err := LoadTarget(Target{Class: tc.class, Path: path})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected malformed YAML error containing %q, got %v", tc.want, err)
+			}
+			var userErr *UserError
+			if !errors.As(err, &userErr) {
+				t.Fatalf("expected UserError, got %T", err)
+			}
+		})
+	}
+}
+
 func TestCheckTargetReusesSharedAliasDefinitionLoader(t *testing.T) {
 	workspace := t.TempDir()
 	path := writeAliasFile(t, workspace, "broken.run.s9s.yaml", "kind: [\n")

--- a/frontend/cli-go/internal/alias/load_test.go
+++ b/frontend/cli-go/internal/alias/load_test.go
@@ -174,6 +174,56 @@ func TestLoadTargetTreatsMalformedYAMLAsUserError(t *testing.T) {
 	}
 }
 
+func TestLoadTargetTreatsMalformedExactFileYAMLAsRequestedUserError(t *testing.T) {
+	tests := []struct {
+		name  string
+		class Class
+		file  string
+		want  string
+	}{
+		{
+			name:  "prepare exact file without alias suffix",
+			class: ClassPrepare,
+			file:  "broken.txt",
+			want:  "read prepare alias",
+		},
+		{
+			name:  "run exact file without alias suffix",
+			class: ClassRun,
+			file:  "broken.txt",
+			want:  "read run alias",
+		},
+		{
+			name:  "prepare exact file with run suffix",
+			class: ClassPrepare,
+			file:  "broken.run.s9s.yaml",
+			want:  "read prepare alias",
+		},
+		{
+			name:  "run exact file with prepare suffix",
+			class: ClassRun,
+			file:  "broken.prep.s9s.yaml",
+			want:  "read run alias",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workspace := t.TempDir()
+			path := writeAliasFile(t, workspace, tc.file, "kind: [\n")
+
+			_, err := LoadTarget(Target{Class: tc.class, Path: path})
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("expected malformed YAML error containing %q, got %v", tc.want, err)
+			}
+			var userErr *UserError
+			if !errors.As(err, &userErr) {
+				t.Fatalf("expected UserError, got %T", err)
+			}
+		})
+	}
+}
+
 func TestCheckTargetReusesSharedAliasDefinitionLoader(t *testing.T) {
 	workspace := t.TempDir()
 	path := writeAliasFile(t, workspace, "broken.run.s9s.yaml", "kind: [\n")

--- a/frontend/cli-go/internal/alias/load_test.go
+++ b/frontend/cli-go/internal/alias/load_test.go
@@ -1,6 +1,7 @@
 package alias
 
 import (
+	"errors"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -115,6 +116,10 @@ func TestLoadTargetRejectsInvalidPrepareSchema(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "unknown prepare alias kind") {
 		t.Fatalf("expected invalid prepare schema error, got %v", err)
 	}
+	var userErr *UserError
+	if !errors.As(err, &userErr) {
+		t.Fatalf("expected UserError, got %T", err)
+	}
 }
 
 func TestLoadTargetRejectsInvalidRunSchema(t *testing.T) {
@@ -124,6 +129,10 @@ func TestLoadTargetRejectsInvalidRunSchema(t *testing.T) {
 	_, err := LoadTarget(Target{Class: ClassRun, Path: path})
 	if err == nil || !strings.Contains(err.Error(), "run alias does not support image") {
 		t.Fatalf("expected invalid run schema error, got %v", err)
+	}
+	var userErr *UserError
+	if !errors.As(err, &userErr) {
+		t.Fatalf("expected UserError, got %T", err)
 	}
 }
 

--- a/frontend/cli-go/internal/app/alias_error.go
+++ b/frontend/cli-go/internal/app/alias_error.go
@@ -1,0 +1,18 @@
+package app
+
+import (
+	"errors"
+
+	aliaspkg "github.com/sqlrs/cli/internal/alias"
+)
+
+func wrapAliasLoadError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var userErr *aliaspkg.UserError
+	if errors.As(err, &userErr) {
+		return ExitErrorf(2, userErr.Message)
+	}
+	return err
+}

--- a/frontend/cli-go/internal/app/alias_error.go
+++ b/frontend/cli-go/internal/app/alias_error.go
@@ -12,7 +12,7 @@ func wrapAliasLoadError(err error) error {
 	}
 	var userErr *aliaspkg.UserError
 	if errors.As(err, &userErr) {
-		return ExitErrorf(2, userErr.Message)
+		return &ExitError{Code: 2, Err: userErr}
 	}
 	return err
 }

--- a/frontend/cli-go/internal/app/alias_error_test.go
+++ b/frontend/cli-go/internal/app/alias_error_test.go
@@ -1,0 +1,28 @@
+package app
+
+import (
+	"errors"
+	"testing"
+
+	aliaspkg "github.com/sqlrs/cli/internal/alias"
+)
+
+func TestWrapAliasLoadErrorBranches(t *testing.T) {
+	if wrapAliasLoadError(nil) != nil {
+		t.Fatalf("expected nil error to stay nil")
+	}
+
+	generic := errors.New("boom")
+	if got := wrapAliasLoadError(generic); !errors.Is(got, generic) {
+		t.Fatalf("expected generic error passthrough, got %v", got)
+	}
+
+	got := wrapAliasLoadError(&aliaspkg.UserError{Message: "bad alias"})
+	exitErr, ok := got.(*ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError, got %T", got)
+	}
+	if exitErr.Code != 2 || got.Error() != "bad alias" {
+		t.Fatalf("unexpected wrapped error: %+v", exitErr)
+	}
+}

--- a/frontend/cli-go/internal/app/alias_error_test.go
+++ b/frontend/cli-go/internal/app/alias_error_test.go
@@ -26,3 +26,19 @@ func TestWrapAliasLoadErrorBranches(t *testing.T) {
 		t.Fatalf("unexpected wrapped error: %+v", exitErr)
 	}
 }
+
+func TestWrapAliasLoadErrorPreservesPercentSigns(t *testing.T) {
+	const message = "unknown prepare alias kind: %s"
+
+	got := wrapAliasLoadError(&aliaspkg.UserError{Message: message})
+	exitErr, ok := got.(*ExitError)
+	if !ok {
+		t.Fatalf("expected ExitError, got %T", got)
+	}
+	if exitErr.Code != 2 {
+		t.Fatalf("expected exit code 2, got %+v", exitErr)
+	}
+	if got.Error() != message {
+		t.Fatalf("error = %q, want %q", got.Error(), message)
+	}
+}

--- a/frontend/cli-go/internal/app/alias_run.go
+++ b/frontend/cli-go/internal/app/alias_run.go
@@ -112,7 +112,7 @@ func resolveRunAliasDefinition(workspaceRoot string, cwd string, ref string) (al
 	}
 	def, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassRun, Path: aliasPath})
 	if err != nil {
-		return aliaspkg.Definition{}, "", err
+		return aliaspkg.Definition{}, "", wrapAliasLoadError(err)
 	}
 	return def, aliasPath, nil
 }

--- a/frontend/cli-go/internal/app/app_alias_additional_coverage_test.go
+++ b/frontend/cli-go/internal/app/app_alias_additional_coverage_test.go
@@ -180,6 +180,50 @@ func TestRunAliasModeReturnsExitCodeTwoForInvalidRunAliasDefinitions(t *testing.
 	}
 }
 
+func TestRunAliasModeReturnsExitCodeTwoForMalformedAliasYAML(t *testing.T) {
+	temp := t.TempDir()
+	setTestDirs(t, temp)
+	workspace := writeAliasWorkspace(t, temp, "http://example.invalid")
+	withWorkingDir(t, workspace)
+	writePrepareAliasFile(t, workspace, "broken.prep.s9s.yaml", "kind: [\n")
+	writeRunAliasFile(t, workspace, "broken.run.s9s.yaml", "kind: [\n")
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "prepare",
+			args: []string{"--workspace", workspace, "prepare", "broken"},
+			want: "read prepare alias",
+		},
+		{
+			name: "plan",
+			args: []string{"--workspace", workspace, "plan", "broken"},
+			want: "read prepare alias",
+		},
+		{
+			name: "run",
+			args: []string{"--workspace", workspace, "run", "broken", "--instance", "dev"},
+			want: "read run alias",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Run(tc.args)
+			var exitErr *ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("expected exit code 2, got %v", err)
+			}
+			if !strings.Contains(exitErr.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, exitErr)
+			}
+		})
+	}
+}
+
 func TestRunPrepareLiquibaseAliasCommand(t *testing.T) {
 	temp := t.TempDir()
 	setTestDirs(t, temp)

--- a/frontend/cli-go/internal/app/app_alias_additional_coverage_test.go
+++ b/frontend/cli-go/internal/app/app_alias_additional_coverage_test.go
@@ -224,6 +224,50 @@ func TestRunAliasModeReturnsExitCodeTwoForMalformedAliasYAML(t *testing.T) {
 	}
 }
 
+func TestRunAliasModeReturnsExitCodeTwoForMalformedExactAliasFiles(t *testing.T) {
+	temp := t.TempDir()
+	setTestDirs(t, temp)
+	workspace := writeAliasWorkspace(t, temp, "http://example.invalid")
+	withWorkingDir(t, workspace)
+	writePrepareAliasFile(t, workspace, "broken.txt", "kind: [\n")
+	writeRunAliasFile(t, workspace, "broken.txt", "kind: [\n")
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "prepare exact file",
+			args: []string{"--workspace", workspace, "prepare", "broken.txt."},
+			want: "read prepare alias",
+		},
+		{
+			name: "plan exact file",
+			args: []string{"--workspace", workspace, "plan", "broken.txt."},
+			want: "read prepare alias",
+		},
+		{
+			name: "run exact file",
+			args: []string{"--workspace", workspace, "run", "broken.txt.", "--instance", "dev"},
+			want: "read run alias",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Run(tc.args)
+			var exitErr *ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("expected exit code 2, got %v", err)
+			}
+			if !strings.Contains(exitErr.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, exitErr)
+			}
+		})
+	}
+}
+
 func TestRunPrepareLiquibaseAliasCommand(t *testing.T) {
 	temp := t.TempDir()
 	setTestDirs(t, temp)

--- a/frontend/cli-go/internal/app/app_alias_additional_coverage_test.go
+++ b/frontend/cli-go/internal/app/app_alias_additional_coverage_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -121,6 +122,61 @@ func TestRunAliasModeReportsRunPathAndLoadErrors(t *testing.T) {
 	err = Run([]string{"--workspace", workspace, "run", "broken", "--instance", "dev"})
 	if err == nil || !strings.Contains(err.Error(), "read run alias") {
 		t.Fatalf("expected invalid alias error, got %v", err)
+	}
+}
+
+func TestRunAliasModeReturnsExitCodeTwoForInvalidPrepareAndPlanAliasDefinitions(t *testing.T) {
+	temp := t.TempDir()
+	setTestDirs(t, temp)
+	workspace := writeAliasWorkspace(t, temp, "http://example.invalid")
+	withWorkingDir(t, workspace)
+	writePrepareAliasFile(t, workspace, "broken.prep.s9s.yaml", "kind: flyway\nargs:\n  - migrate\n")
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "prepare",
+			args: []string{"--workspace", workspace, "prepare", "broken"},
+			want: "unknown prepare alias kind",
+		},
+		{
+			name: "plan",
+			args: []string{"--workspace", workspace, "plan", "broken"},
+			want: "unknown prepare alias kind",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := Run(tc.args)
+			var exitErr *ExitError
+			if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+				t.Fatalf("expected exit code 2, got %v", err)
+			}
+			if !strings.Contains(exitErr.Error(), tc.want) {
+				t.Fatalf("expected error containing %q, got %v", tc.want, exitErr)
+			}
+		})
+	}
+}
+
+func TestRunAliasModeReturnsExitCodeTwoForInvalidRunAliasDefinitions(t *testing.T) {
+	temp := t.TempDir()
+	setTestDirs(t, temp)
+	workspace := writeAliasWorkspace(t, temp, "http://example.invalid")
+	withWorkingDir(t, workspace)
+	writeRunAliasFile(t, workspace, "broken.run.s9s.yaml", "kind: psql\nimage: postgres:17\nargs:\n  - -c\n  - select 1\n")
+
+	err := Run([]string{"--workspace", workspace, "run", "broken", "--instance", "dev"})
+	var exitErr *ExitError
+	if !errors.As(err, &exitErr) || exitErr.Code != 2 {
+		t.Fatalf("expected exit code 2, got %v", err)
+	}
+	if !strings.Contains(exitErr.Error(), "run alias does not support image") {
+		t.Fatalf("expected invalid run alias error, got %v", exitErr)
 	}
 }
 

--- a/frontend/cli-go/internal/app/ref_alias.go
+++ b/frontend/cli-go/internal/app/ref_alias.go
@@ -13,7 +13,7 @@ func resolvePrepareAliasWithOptionalRef(workspaceRoot string, cwd string, aliasR
 		}
 		alias, err := aliaspkg.LoadTarget(aliaspkg.Target{Class: aliaspkg.ClassPrepare, Path: aliasPath})
 		if err != nil {
-			return aliaspkg.Definition{}, "", nil, err
+			return aliaspkg.Definition{}, "", nil, wrapAliasLoadError(err)
 		}
 		return alias, aliasPath, nil, nil
 	}
@@ -30,7 +30,7 @@ func resolvePrepareAliasWithOptionalRef(workspaceRoot string, cwd string, aliasR
 	alias, err := aliaspkg.LoadTargetWithFS(aliaspkg.Target{Class: aliaspkg.ClassPrepare, Path: aliasPath}, ctx.FileSystem)
 	if err != nil {
 		_ = ctx.Cleanup()
-		return aliaspkg.Definition{}, "", nil, err
+		return aliaspkg.Definition{}, "", nil, wrapAliasLoadError(err)
 	}
 	return alias, aliasPath, &ctx, nil
 }


### PR DESCRIPTION
## Summary

This PR implements PR2 from the CLI maintainability refactor by making `frontend/cli-go/internal/alias` the canonical owner of execution-facing alias definitions.

The main goal is to remove duplicated alias loading and schema validation logic from `internal/app` so that alias inspection and alias execution read the same prepare/run schema rules, while keeping path resolution and command orchestration in `internal/app` for now.

## What Changed

- Added a canonical alias `Definition` model in `internal/alias`.
- Added shared alias loaders:
  - `LoadTarget`
  - `LoadTargetWithFS`
- Centralized prepare/run alias YAML loading, normalization, and schema validation in `internal/alias`.
- Updated alias inspection to reuse the same loader and validation rules instead of maintaining its own duplicate schema handling.
- Switched alias execution in `internal/app` to consume the shared alias domain model for:
  - `prepare`
  - `plan`
  - `run`
- Kept ref-backed prepare alias execution working by supporting filesystem-aware alias loading.
- Added alias-specific user error wrapping so invalid alias definitions still surface as usage errors with historical CLI behavior.
- Fixed malformed alias YAML handling so it is treated as a user-facing usage error as well.
- Fixed malformed exact-file alias refs so errors are classified by the requested alias class rather than by the file suffix.
- Updated architecture docs and added an ADR describing the canonical alias domain boundary.

## Scope / Non-Goals

- No CLI syntax changes.
- Alias path resolution remains in `internal/app` in this PR.
- This PR is intentionally limited to canonical alias definition ownership and error-behavior preservation.

## Why

Before this change, `internal/app` and `internal/alias` both owned pieces of alias definition parsing and validation. That split made it easy for inspection and execution behavior to drift apart.

After this change:

- one canonical alias-definition loader exists in `internal/alias`;
- inspection and execution share the same schema rules;
- app-layer execution code consumes a shared alias model instead of re-reading YAML directly;
- user-facing error behavior remains stable, including malformed YAML and exact-file alias refs.

## Testing

- `go test ./frontend/cli-go/internal/alias -count=1`
- `go test ./frontend/cli-go/internal/app -run Alias -count=1`
