### PR TITLE
unifying the duplicated `plan` / `prepare` orchestration in `frontend/cli-go/internal/app`

### DIFF
--- a/docs/adr/2026-04-20-plan-prepare-stage-pipeline-shape.md
+++ b/docs/adr/2026-04-20-plan-prepare-stage-pipeline-shape.md
@@ -1,0 +1,70 @@
+# 2026-04-20 Plan/Prepare Stage Pipeline Shape
+
+- Conversation timestamp: 2026-04-20T09:35:20.0434251+07:00
+- GitHub user id: @evilguest
+- Agent name/version: Codex / GPT-5
+- Status: Accepted
+
+## Decision Record 1: where to place the shared plan/prepare pipeline boundary
+
+### Question discussed
+
+For the CLI maintainability `PR4`, how should `sqlrs plan` and `sqlrs prepare`
+share one internal pipeline without changing the public CLI contract or
+overreaching into transport/runtime layers?
+
+### Alternatives considered
+
+1. Keep the existing split and only extract a few helper functions from
+   `plan.go` and `prepare.go`.
+2. Move the shared plan/prepare pipeline down into `internal/cli` so transport
+   execution and app-level orchestration are unified together.
+3. Introduce one shared package-local stage pipeline in `internal/app`, keep
+   kind-specific binding in `ref_prepare.go`, and keep terminal transport
+   behavior in `internal/cli`.
+
+### Chosen solution
+
+Adopt option 3.
+
+`PR4` is scoped to:
+
+- one shared package-local stage pipeline in `frontend/cli-go/internal/app`;
+- one shared request/runtime model for `plan` and `prepare` stage execution;
+- shared image resolution, bind orchestration, and cleanup handling;
+- mode-specific terminal actions only for:
+  - `plan` result waiting and rendering;
+  - `prepare` submit/watch handling and DSN/job-ref rendering;
+- reuse of the same pipeline by direct and alias-backed `plan` / `prepare`
+  paths.
+
+Explicitly out of scope:
+
+- changing CLI syntax, output shape, watch semantics, or exit codes;
+- moving the transport contract out of `frontend/cli-go/internal/cli`;
+- redesigning `internal/refctx` or alias path resolution;
+- folding composite `run` orchestration into the same pipeline.
+
+### Brief rationale
+
+The current duplication sits in CLI-side orchestration, not in the transport
+layer. A small helper-only pass would keep the ownership blurry, while pushing
+the boundary into `internal/cli` would mix app-level command semantics with
+runtime execution. Keeping the shared pipeline in `internal/app` removes the
+duplicated parse/bind/config/invoke/cleanup flow while preserving the existing
+ownership of ref-aware binding and transport behavior.
+
+## Related documents
+
+- `docs/architecture/cli-maintainability-refactor.md`
+- `docs/architecture/cli-component-structure.md`
+- `docs/architecture/ref-component-structure.md`
+- `docs/adr/2026-04-16-cli-maintainability-pr-sequencing.md`
+
+## Contradiction check
+
+No existing ADR was marked obsolete.
+
+This ADR refines the accepted `PR4` step from
+`docs/adr/2026-04-16-cli-maintainability-pr-sequencing.md`; it does not replace
+that sequencing decision.

--- a/docs/architecture/cli-maintainability-refactor.RU.md
+++ b/docs/architecture/cli-maintainability-refactor.RU.md
@@ -121,6 +121,8 @@ feature-by-feature срезов:
 разбить aliases analyzer на более узкие внутренние фазы: scan, score,
 validate и suppress.
 
+Статус: реализовано в текущей ветке.
+
 ### 5.4 PR4: shared stage pipeline для plan/prepare
 
 Свести текущие execution flow `plan` и `prepare` к одному internal stage
@@ -334,3 +336,156 @@ alias-definition owner.
 
 Точный split по test files не важен, но PR должен доказать, что prepare/run
 execution и alias inspection больше не держат независимые YAML schema loader-ы.
+
+## 11. Дизайн PR4
+
+### 11.1 Scope
+
+PR4 — это первый проход по объединению pipeline для `plan` / `prepare`. Он
+тоже остаётся намеренно узким.
+
+Входит:
+
+- один shared package-local stage pipeline в `internal/app` для direct и
+  alias-backed entrypoint-ов `plan` / `prepare`;
+- одна shared request model для stage mode (`plan` vs `prepare`), kind
+  (`psql` vs `lb`), распарсенных stage args, `workspace`/`cwd`, optional
+  ref context и policy для Liquibase path mode;
+- одна shared binding phase, которая один раз делает image/config resolution,
+  вызывает существующие kind-specific binder-ы и возвращает полностью
+  подготовленные `cli.PrepareOptions` плюс cleanup;
+- mode-specific terminal actions только там, где behavior действительно
+  различается: `plan` ждёт plan-only result и рендерит plan output, а
+  `prepare` либо submit-ит prepare job, либо ждёт его и рендерит DSN или
+  accepted-job references;
+- thin facade-ы в `plan.go` / `prepare.go` поверх этого shared pipeline.
+
+Явно вне scope PR4:
+
+- изменение CLI syntax, usage text, JSON payload-ов, watch semantics или
+  exit-code behavior;
+- изменение transport-facing contract в `internal/cli`
+  (`PrepareOptions`, `RunPlan`, `RunPrepare`, `SubmitPrepare`);
+- втягивание composite orchestration для `run` в тот же pipeline;
+- вынос `bindPreparePsqlInputs` / `bindPrepareLiquibaseInputs` из
+  `internal/app`;
+- redesign alias path resolution или `internal/refctx`.
+
+Смысл PR4 — убрать duplicate CLI orchestration, а не redesign всей execution
+domain для prepare/plan.
+
+### 11.2 Целевая форма
+
+`internal/app` становится владельцем одного shared package-local stage
+pipeline для prepare-oriented команд.
+
+Ожидаемые internal pieces:
+
+- `stageRunRequest`
+  - immutable описание одного invocation:
+    - mode (`plan` или `prepare`)
+    - kind (`psql` или `lb`)
+    - распарсенные `prepareArgs`
+    - `workspaceRoot`
+    - `cwd`
+    - optional `refctx.Context`
+    - output mode для `plan`
+    - Liquibase path-mode flags там, где direct и alias-backed flow
+      различаются;
+- `stageRuntime`
+  - shared bound runtime, который возвращает pipeline:
+    - полностью заполненные `cli.PrepareOptions`
+    - cleanup hook
+    - rendering metadata, нужные после execution;
+- одна shared bind/prepare function
+  - один раз делает base-image resolution и verbose image message;
+  - валидирует mode-specific constraints, например запрет watch flags для
+    `plan`;
+  - dispatch-ит в существующие `psql` / Liquibase binder-ы;
+  - заполняет shared payload `cli.PrepareOptions`;
+- один небольшой слой mode-specific terminal action
+  - `plan` вызывает `cli.RunPlan` и рендерит human/JSON plan output;
+  - `prepare` вызывает `cli.RunPrepare` или `cli.SubmitPrepare` и рендерит DSN
+    или accepted job references.
+
+Правила владения:
+
+- `plan.go` и `prepare.go` должны сохранить user-facing entrypoint helper-ы,
+  но больше не должны дублировать bind/config/invoke orchestration;
+- `ref_prepare.go` остаётся владельцем ref-aware kind binding и staging;
+- `internal/cli` остаётся владельцем transport, waiting и remote/local engine
+  interaction;
+- alias-backed flow для `plan` / `prepare` должны переиспользовать тот же
+  shared pipeline, создавая ту же request model, а не отдельную копию
+  orchestration.
+
+### 11.3 Shared interaction flow
+
+Shared flow для direct и alias-backed `plan` / `prepare` должен быть таким:
+
+1. Распарсить или заранее сконструировать `prepareArgs` ровно один раз.
+2. Создать `stageRunRequest`, который фиксирует mode, kind, `cwd`/`workspace`,
+   output, ref context и path-mode policy.
+3. Один раз вычислить shared runtime inputs:
+   - провалидировать mode-specific flags;
+   - выполнить image resolution и вывести verbose image message;
+   - вычислить настройки Liquibase executable там, где это нужно;
+   - привязать file-bearing inputs через существующие kind-specific binder-ы.
+4. Сформировать один `stageRuntime`, содержащий подготовленные
+   `cli.PrepareOptions` и cleanup.
+5. Выполнить terminal action для выбранного mode:
+   - `plan`: дождаться plan-only result;
+   - `prepare --watch`: дождаться prepare result;
+   - `prepare --no-watch`: submit-нуть job и вывести job references.
+6. Отрендерить mode-specific output и выполнить cleanup ровно один раз.
+
+Такой разрез оставляет shared boundary на уровне CLI orchestration, где сейчас
+и находится дублирование, и не проталкивает command semantics вниз в
+`internal/cli`, `internal/inputset` или `internal/refctx`.
+
+### 11.4 Ожидаемое движение файлов
+
+PR4 должен в основном затронуть:
+
+- `frontend/cli-go/internal/app/plan.go`
+- `frontend/cli-go/internal/app/prepare.go`
+- `frontend/cli-go/internal/app/ref_prepare.go`
+- `frontend/cli-go/internal/app/runner.go`
+- связанные `internal/app/*test.go` файлы для direct и alias-backed путей
+  `plan` / `prepare`.
+
+Новый код, скорее всего, должен остаться внутри `internal/app`, например в
+одном или двух новых package-local файлах с shared helper-ами для
+stage request/runtime.
+
+### 11.5 Критерии успеха
+
+PR4 считается успешным, если:
+
+- `plan` и `prepare` больше не дублируют image resolution, kind dispatch,
+  binder invocation и cleanup orchestration;
+- direct и alias-backed пути `plan` / `prepare` переиспользуют один и тот же
+  shared stage pipeline;
+- behavior для watch, no-watch, ref-backed и Liquibase path остаётся прежним;
+- public CLI syntax, output и exit-code behavior не меняются.
+
+## 12. Тест-план для PR4
+
+Четвёртый implementation slice должен добавить или обновить тесты вокруг
+shared stage pipeline.
+
+Ожидаемые тесты:
+
+1. `TestStagePipelinePlanPsqlRendersHumanAndJSONOutputs`
+2. `TestStagePipelinePreparePsqlWatchRunsPrepare`
+3. `TestStagePipelinePrepareNoWatchSubmitsAndPrintsRefs`
+4. `TestStagePipelineLiquibaseResolvesExecAndWorkDirOnce`
+5. `TestStagePipelineRejectsPlanWatchFlagsBeforeInvocation`
+6. `TestStagePipelineRejectsLiquibaseWithoutCommand`
+7. `TestAliasBackedPlanAndPrepareReuseSharedStagePipeline`
+8. `TestStagePipelineRunsCleanupOnBindAndInvokeErrors`
+9. `TestStagePipelineDisablesPrepareControlPromptForRefBackedPrepare`
+
+Точный split по test files не важен, но PR должен доказать, что shared
+pipeline владеет общей orchestration для `plan` / `prepare` и при этом
+сохраняет текущее mode-specific behavior.

--- a/docs/architecture/cli-maintainability-refactor.md
+++ b/docs/architecture/cli-maintainability-refactor.md
@@ -121,6 +121,8 @@ Separate generic discovery report types from the aliases analyzer and then split
 the aliases analyzer into narrower internal phases such as scan, score,
 validate, and suppress.
 
+Status: Implemented in the current branch.
+
 ### 5.4 PR4: shared plan/prepare stage pipeline
 
 Unify the current `plan` and `prepare` execution flow behind one internal stage
@@ -334,3 +336,153 @@ Expected tests:
 The exact test file split is not important, but the PR should prove that
 prepare/run execution and alias inspection no longer maintain independent YAML
 schema loaders.
+
+## 11. PR4 Design
+
+### 11.1 Scope
+
+PR4 is the first `plan` / `prepare` pipeline unification pass. It is still
+intentionally narrow.
+
+Included:
+
+- one shared package-local stage pipeline in `internal/app` for direct and
+  alias-backed `plan` / `prepare` entrypoints;
+- one shared request model for stage mode (`plan` vs `prepare`), kind
+  (`psql` vs `lb`), parsed stage args, workspace/cwd, optional ref context, and
+  Liquibase path-mode policy;
+- one shared binding phase that resolves image/config, runs the existing
+  kind-specific binders, and returns fully prepared `cli.PrepareOptions` plus
+  cleanup;
+- mode-specific terminal actions only where behavior actually differs:
+  `plan` waits for a plan-only result and renders plan output, while `prepare`
+  either submits or waits for a prepare job and renders DSN or accepted-job
+  references;
+- thin `plan.go` / `prepare.go` facades over that shared pipeline.
+
+Explicitly out of scope for PR4:
+
+- changing CLI syntax, usage text, JSON payloads, watch semantics, or exit-code
+  behavior;
+- changing the transport-facing contract in `internal/cli`
+  (`PrepareOptions`, `RunPlan`, `RunPrepare`, `SubmitPrepare`);
+- pulling `run` composite orchestration into the same pipeline;
+- moving `bindPreparePsqlInputs` / `bindPrepareLiquibaseInputs` out of
+  `internal/app`;
+- redesigning alias path resolution or `internal/refctx`.
+
+The point of PR4 is to remove duplicated CLI orchestration, not to redesign the
+prepare/plan execution domain.
+
+### 11.2 Target shape
+
+`internal/app` becomes the owner of one shared package-local stage pipeline for
+prepare-oriented commands.
+
+Expected internal pieces:
+
+- `stageRunRequest`
+  - immutable description of one invocation:
+    - mode (`plan` or `prepare`)
+    - kind (`psql` or `lb`)
+    - parsed `prepareArgs`
+    - `workspaceRoot`
+    - `cwd`
+    - optional `refctx.Context`
+    - output mode for `plan`
+    - Liquibase path-mode flags where alias-backed and direct flows differ;
+- `stageRuntime`
+  - shared bound runtime returned by the pipeline:
+    - fully populated `cli.PrepareOptions`
+    - cleanup hook
+    - rendering metadata needed after execution;
+- one shared bind/prepare function
+  - resolves the base image and verbose source message once;
+  - validates mode-specific constraints such as `plan` rejecting watch flags;
+  - dispatches to the existing `psql` / Liquibase binders;
+  - fills the shared `cli.PrepareOptions` payload;
+- one small mode-specific terminal-action layer
+  - `plan` invokes `cli.RunPlan` and renders human/JSON plan output;
+  - `prepare` invokes `cli.RunPrepare` or `cli.SubmitPrepare` and renders DSN
+    or accepted job references.
+
+Ownership rules:
+
+- `plan.go` and `prepare.go` should keep user-facing entrypoint helpers, but
+  no longer duplicate bind/config/invoke orchestration;
+- `ref_prepare.go` remains the owner of ref-aware kind binding and staging;
+- `internal/cli` remains the owner of transport, waiting, and remote/local
+  engine interaction;
+- alias-backed `plan` / `prepare` flows should reuse the same shared pipeline
+  by constructing the same request model instead of keeping a separate copy of
+  the orchestration.
+
+### 11.3 Shared interaction flow
+
+The shared flow for both direct and alias-backed `plan` / `prepare` should be:
+
+1. Parse or preconstruct `prepareArgs` exactly once.
+2. Create a `stageRunRequest` that captures mode, kind, cwd/workspace, output,
+   ref context, and path-mode policy.
+3. Resolve shared runtime inputs once:
+   - validate mode-specific flags;
+   - resolve image source and emit the verbose image message;
+   - resolve Liquibase executable settings when required;
+   - bind file-bearing inputs through the existing kind-specific binders.
+4. Produce one `stageRuntime` containing prepared `cli.PrepareOptions` and
+   cleanup.
+5. Invoke the terminal action for the selected mode:
+   - `plan`: wait for a plan-only result;
+   - `prepare --watch`: wait for a prepare result;
+   - `prepare --no-watch`: submit and print job references.
+6. Render the mode-specific output and run cleanup exactly once.
+
+This keeps the shared boundary at the CLI orchestration layer, where the
+duplication currently exists, and avoids pushing command semantics down into
+`internal/cli`, `internal/inputset`, or `internal/refctx`.
+
+### 11.4 Expected file movement
+
+PR4 should mostly touch:
+
+- `frontend/cli-go/internal/app/plan.go`
+- `frontend/cli-go/internal/app/prepare.go`
+- `frontend/cli-go/internal/app/ref_prepare.go`
+- `frontend/cli-go/internal/app/runner.go`
+- related `internal/app/*test.go` files for direct and alias-backed
+  `plan` / `prepare` paths.
+
+The likely new code should stay inside `internal/app`, for example in one or
+two new package-local files that host the shared stage request/runtime helpers.
+
+### 11.5 Success criteria
+
+PR4 is successful if:
+
+- `plan` and `prepare` no longer duplicate image resolution, kind dispatch,
+  binder invocation, and cleanup orchestration;
+- direct and alias-backed `plan` / `prepare` paths reuse the same shared stage
+  pipeline;
+- watch, no-watch, ref-backed, and Liquibase path behavior remain unchanged;
+- public CLI syntax, output, and exit-code behavior remain unchanged.
+
+## 12. PR4 Test Plan
+
+The fourth implementation slice should add or update tests around the shared
+stage pipeline.
+
+Expected tests:
+
+1. `TestStagePipelinePlanPsqlRendersHumanAndJSONOutputs`
+2. `TestStagePipelinePreparePsqlWatchRunsPrepare`
+3. `TestStagePipelinePrepareNoWatchSubmitsAndPrintsRefs`
+4. `TestStagePipelineLiquibaseResolvesExecAndWorkDirOnce`
+5. `TestStagePipelineRejectsPlanWatchFlagsBeforeInvocation`
+6. `TestStagePipelineRejectsLiquibaseWithoutCommand`
+7. `TestAliasBackedPlanAndPrepareReuseSharedStagePipeline`
+8. `TestStagePipelineRunsCleanupOnBindAndInvokeErrors`
+9. `TestStagePipelineDisablesPrepareControlPromptForRefBackedPrepare`
+
+The exact test file split is not important, but the PR should prove that the
+shared pipeline owns common plan/prepare orchestration while preserving current
+mode-specific behavior.

--- a/docs/roadmap.RU.md
+++ b/docs/roadmap.RU.md
@@ -72,7 +72,7 @@ gantt
 
 ---
 
-## Статус (на 2026-04-08)
+## Статус (на 2026-04-20)
 
 - **Сделано**: локальная поверхность API (health, config, names, instances, runs,
   states, prepare jobs, tasks), локальный runtime и lifecycle, end-to-end pipeline
@@ -124,6 +124,11 @@ gantt
   default-запуском по всем shipped analyzers, analyzer-grouped human/JSON
   output, failure isolation и shell-aware follow-up командами для исправлений в
   `.gitignore` и `.vscode`.
+- **Сделано (CLI maintainability PR4 stage pipeline)**: direct и alias-backed
+  flow для `plan` / `prepare` в `internal/app` теперь разделяют один
+  package-local stage pipeline для image resolution, kind-specific binding,
+  terminal invocation и cleanup handling, что убирает дублирование
+  orchestration без изменения публичного CLI-контракта.
 - **Сделано (M2 shared inputset + diff path baseline)**: CLI теперь включает
   `sqlrs diff --from-path/--to-path` для `prepare:psql` и `prepare:lb`, а
   `prepare`, `plan`, `run`, `diff` и `alias check` теперь разделяют единый

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,7 +71,7 @@ gantt
 
 ---
 
-## Status (as of 2026-04-08)
+## Status (as of 2026-04-20)
 
 - **Done**: local engine API surface (health, config, names, instances, runs,
   states, prepare jobs, tasks), local runtime and lifecycle, end-to-end
@@ -123,6 +123,11 @@ gantt
   stable default execution over all shipped analyzers, analyzer-grouped
   human/JSON output, failure isolation, and shell-aware follow-up commands for
   `.gitignore` and `.vscode` remediation suggestions.
+- **Done (CLI maintainability PR4 stage pipeline)**: direct and alias-backed
+  `plan` / `prepare` flows in `internal/app` now share one package-local stage
+  pipeline for image resolution, kind-specific binding, terminal invocation,
+  and cleanup handling, reducing duplicated orchestration without changing the
+  public CLI contract.
 - **Done (M2 shared inputset + diff path baseline)**: the CLI now ships
   `sqlrs diff --from-path/--to-path` for `prepare:psql` and `prepare:lb`, while
   `prepare`, `plan`, `run`, `diff`, and `alias check` now share one

--- a/frontend/cli-go/internal/app/plan.go
+++ b/frontend/cli-go/internal/app/plan.go
@@ -1,10 +1,7 @@
 package app
 
 import (
-	"context"
-	"fmt"
 	"io"
-	"os"
 
 	"github.com/sqlrs/cli/internal/cli"
 	"github.com/sqlrs/cli/internal/config"
@@ -32,70 +29,18 @@ func runPlanKindWithPathMode(stdout, stderr io.Writer, runOpts cli.PrepareOption
 }
 
 func runPlanKindParsedWithPathMode(stdout, stderr io.Writer, runOpts cli.PrepareOptions, cfg config.LoadedConfig, workspaceRoot string, cwd string, parsed prepareArgs, ref *refctx.Context, output string, kind string, relativizeLiquibasePaths bool) error {
-	if parsed.WatchSpecified {
-		return ExitErrorf(2, "plan does not support --watch/--no-watch")
-	}
-
-	if kind == "lb" && len(parsed.PsqlArgs) == 0 {
-		return ExitErrorf(2, "liquibase command is required")
-	}
-
-	imageID, source, err := resolvePrepareImage(parsed.Image, cfg)
+	runtime, err := buildStageRuntime(stderr, runOpts, cfg, stageRunRequest{
+		mode:                    stageModePlan,
+		kind:                    kind,
+		parsed:                  parsed,
+		workspaceRoot:           workspaceRoot,
+		cwd:                     cwd,
+		ref:                     ref,
+		output:                  output,
+		relativizeLiquibasePath: relativizeLiquibasePaths,
+	})
 	if err != nil {
 		return err
 	}
-	if imageID == "" {
-		return ExitErrorf(2, "Missing base image id (set --image or dbms.image)")
-	}
-	if runOpts.Verbose {
-		fmt.Fprint(stderr, formatImageSource(imageID, source))
-	}
-
-	var cleanup func() error
-	switch kind {
-	case "psql":
-		bound, err := bindPreparePsqlInputsFn(runOpts, workspaceRoot, cwd, parsed, ref, os.Stdin)
-		if err != nil {
-			return err
-		}
-		cleanup = bound.cleanup
-		runOpts.ImageID = imageID
-		runOpts.PsqlArgs = bound.PsqlArgs
-		runOpts.Stdin = bound.Stdin
-		runOpts.PrepareKind = "psql"
-		runOpts.PlanOnly = true
-	case "lb":
-		liquibaseExec, err := resolveLiquibaseExec(cfg)
-		if err != nil {
-			return err
-		}
-		liquibaseExecMode, err := resolveLiquibaseExecMode(cfg)
-		if err != nil {
-			return err
-		}
-		bound, err := bindPrepareLiquibaseInputsFn(runOpts, workspaceRoot, cwd, parsed, ref, liquibaseExec, liquibaseExecMode, relativizeLiquibasePaths)
-		if err != nil {
-			return err
-		}
-		cleanup = bound.cleanup
-		runOpts.ImageID = imageID
-		runOpts.LiquibaseArgs = bound.LiquibaseArgs
-		runOpts.LiquibaseExec = liquibaseExec
-		runOpts.LiquibaseExecMode = liquibaseExecMode
-		runOpts.LiquibaseEnv = resolveLiquibaseEnv()
-		runOpts.WorkDir = bound.WorkDir
-		runOpts.PrepareKind = "lb"
-		runOpts.PlanOnly = true
-	default:
-		return ExitErrorf(2, "unsupported plan kind: %s", kind)
-	}
-
-	result, err := runPlanFn(context.Background(), runOpts)
-	if err != nil {
-		return finishPrepareCleanup(err, cleanup)
-	}
-	if output == "json" {
-		return finishPrepareCleanup(writeJSON(stdout, result), cleanup)
-	}
-	return finishPrepareCleanup(cli.PrintPlan(stdout, result), cleanup)
+	return executePlanStage(stdout, runtime, output)
 }

--- a/frontend/cli-go/internal/app/prepare.go
+++ b/frontend/cli-go/internal/app/prepare.go
@@ -1,7 +1,6 @@
 package app
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -225,64 +224,18 @@ func prepareResult(w stdoutAndErr, runOpts cli.PrepareOptions, cfg config.Loaded
 }
 
 func prepareResultParsed(w stdoutAndErr, runOpts cli.PrepareOptions, cfg config.LoadedConfig, workspaceRoot string, cwd string, parsed prepareArgs, ref *refctx.Context) (result client.PrepareJobResult, handled bool, err error) {
-	imageID, source, err := resolvePrepareImage(parsed.Image, cfg)
+	runtime, err := buildStageRuntime(w.stderr, runOpts, cfg, stageRunRequest{
+		mode:          stageModePrepare,
+		kind:          "psql",
+		parsed:        parsed,
+		workspaceRoot: workspaceRoot,
+		cwd:           cwd,
+		ref:           ref,
+	})
 	if err != nil {
 		return client.PrepareJobResult{}, false, err
 	}
-	if imageID == "" {
-		return client.PrepareJobResult{}, false, ExitErrorf(2, "Missing base image id (set --image or dbms.image)")
-	}
-	if runOpts.Verbose {
-		fmt.Fprint(w.stderr, formatImageSource(imageID, source))
-	}
-
-	bound, err := bindPreparePsqlInputsFn(runOpts, workspaceRoot, cwd, parsed, ref, os.Stdin)
-	if err != nil {
-		return client.PrepareJobResult{}, false, err
-	}
-	cleanupOnReturn := true
-	defer func() {
-		if cleanupOnReturn {
-			err = finishPrepareCleanup(err, bound.cleanup)
-		}
-	}()
-
-	runOpts.ImageID = imageID
-	runOpts.PsqlArgs = bound.PsqlArgs
-	runOpts.Stdin = bound.Stdin
-	runOpts.PrepareKind = "psql"
-	runOpts.DisableControlPrompt = usesPrepareRef(parsed, ref)
-
-	if !parsed.Watch {
-		accepted, err := submitPrepareFn(context.Background(), runOpts)
-		if err != nil {
-			return client.PrepareJobResult{}, false, err
-		}
-		printPrepareJobRefs(w.stdout, accepted)
-		if runOpts.CompositeRun {
-			printRunSkipped(w.stdout, "prepare_not_watched")
-		}
-		return client.PrepareJobResult{}, true, nil
-	}
-
-	result, err = runPrepareFn(context.Background(), runOpts)
-	if err != nil {
-		var detached *cli.PrepareDetachedError
-		if errors.As(err, &detached) {
-			accepted := client.PrepareJobAccepted{
-				JobID:     detached.JobID,
-				StatusURL: "/v1/prepare-jobs/" + detached.JobID,
-				EventsURL: "/v1/prepare-jobs/" + detached.JobID + "/events",
-			}
-			printPrepareJobRefs(w.stdout, accepted)
-			if runOpts.CompositeRun {
-				printRunSkipped(w.stdout, "prepare_detached")
-			}
-			return client.PrepareJobResult{}, true, nil
-		}
-		return client.PrepareJobResult{}, false, err
-	}
-	return result, false, nil
+	return executePrepareStage(w, runtime)
 }
 
 func prepareResultLiquibase(w stdoutAndErr, runOpts cli.PrepareOptions, cfg config.LoadedConfig, workspaceRoot string, cwd string, args []string) (client.PrepareJobResult, bool, error) {
@@ -305,80 +258,19 @@ func prepareResultLiquibaseWithPathMode(w stdoutAndErr, runOpts cli.PrepareOptio
 }
 
 func prepareResultLiquibaseParsedWithPathMode(w stdoutAndErr, runOpts cli.PrepareOptions, cfg config.LoadedConfig, workspaceRoot string, cwd string, parsed prepareArgs, ref *refctx.Context, relativizePaths bool) (result client.PrepareJobResult, handled bool, err error) {
-	if len(parsed.PsqlArgs) == 0 {
-		return client.PrepareJobResult{}, false, ExitErrorf(2, "liquibase command is required")
-	}
-
-	imageID, source, err := resolvePrepareImage(parsed.Image, cfg)
+	runtime, err := buildStageRuntime(w.stderr, runOpts, cfg, stageRunRequest{
+		mode:                    stageModePrepare,
+		kind:                    "lb",
+		parsed:                  parsed,
+		workspaceRoot:           workspaceRoot,
+		cwd:                     cwd,
+		ref:                     ref,
+		relativizeLiquibasePath: relativizePaths,
+	})
 	if err != nil {
 		return client.PrepareJobResult{}, false, err
 	}
-	if imageID == "" {
-		return client.PrepareJobResult{}, false, ExitErrorf(2, "Missing base image id (set --image or dbms.image)")
-	}
-	if runOpts.Verbose {
-		fmt.Fprint(w.stderr, formatImageSource(imageID, source))
-	}
-
-	liquibaseExec, err := resolveLiquibaseExec(cfg)
-	if err != nil {
-		return client.PrepareJobResult{}, false, err
-	}
-	liquibaseExecMode, err := resolveLiquibaseExecMode(cfg)
-	if err != nil {
-		return client.PrepareJobResult{}, false, err
-	}
-	liquibaseEnv := resolveLiquibaseEnv()
-	bound, err := bindPrepareLiquibaseInputsFn(runOpts, workspaceRoot, cwd, parsed, ref, liquibaseExec, liquibaseExecMode, relativizePaths)
-	if err != nil {
-		return client.PrepareJobResult{}, false, err
-	}
-	cleanupOnReturn := true
-	defer func() {
-		if cleanupOnReturn {
-			err = finishPrepareCleanup(err, bound.cleanup)
-		}
-	}()
-
-	runOpts.ImageID = imageID
-	runOpts.LiquibaseArgs = bound.LiquibaseArgs
-	runOpts.LiquibaseExec = liquibaseExec
-	runOpts.LiquibaseExecMode = liquibaseExecMode
-	runOpts.LiquibaseEnv = liquibaseEnv
-	runOpts.WorkDir = bound.WorkDir
-	runOpts.PrepareKind = "lb"
-	runOpts.DisableControlPrompt = usesPrepareRef(parsed, ref)
-
-	if !parsed.Watch {
-		accepted, err := submitPrepareFn(context.Background(), runOpts)
-		if err != nil {
-			return client.PrepareJobResult{}, false, err
-		}
-		printPrepareJobRefs(w.stdout, accepted)
-		if runOpts.CompositeRun {
-			printRunSkipped(w.stdout, "prepare_not_watched")
-		}
-		return client.PrepareJobResult{}, true, nil
-	}
-
-	result, err = runPrepareFn(context.Background(), runOpts)
-	if err != nil {
-		var detached *cli.PrepareDetachedError
-		if errors.As(err, &detached) {
-			accepted := client.PrepareJobAccepted{
-				JobID:     detached.JobID,
-				StatusURL: "/v1/prepare-jobs/" + detached.JobID,
-				EventsURL: "/v1/prepare-jobs/" + detached.JobID + "/events",
-			}
-			printPrepareJobRefs(w.stdout, accepted)
-			if runOpts.CompositeRun {
-				printRunSkipped(w.stdout, "prepare_detached")
-			}
-			return client.PrepareJobResult{}, true, nil
-		}
-		return client.PrepareJobResult{}, false, err
-	}
-	return result, false, nil
+	return executePrepareStage(w, runtime)
 }
 
 func usesPrepareRef(parsed prepareArgs, ref *refctx.Context) bool {

--- a/frontend/cli-go/internal/app/stage_pipeline.go
+++ b/frontend/cli-go/internal/app/stage_pipeline.go
@@ -1,0 +1,160 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/sqlrs/cli/internal/cli"
+	"github.com/sqlrs/cli/internal/client"
+	"github.com/sqlrs/cli/internal/config"
+	"github.com/sqlrs/cli/internal/refctx"
+)
+
+type stageMode string
+
+const (
+	stageModePrepare stageMode = "prepare"
+	stageModePlan    stageMode = "plan"
+)
+
+type stageRunRequest struct {
+	mode                    stageMode
+	kind                    string
+	parsed                  prepareArgs
+	workspaceRoot           string
+	cwd                     string
+	ref                     *refctx.Context
+	output                  string
+	relativizeLiquibasePath bool
+}
+
+type stageRuntime struct {
+	opts    cli.PrepareOptions
+	watch   bool
+	cleanup func() error
+}
+
+func buildStageRuntime(stderr io.Writer, runOpts cli.PrepareOptions, cfg config.LoadedConfig, req stageRunRequest) (stageRuntime, error) {
+	if req.mode == stageModePlan && req.parsed.WatchSpecified {
+		return stageRuntime{}, ExitErrorf(2, "plan does not support --watch/--no-watch")
+	}
+	if req.kind == "lb" && len(req.parsed.PsqlArgs) == 0 {
+		return stageRuntime{}, ExitErrorf(2, "liquibase command is required")
+	}
+
+	imageID, source, err := resolvePrepareImage(req.parsed.Image, cfg)
+	if err != nil {
+		return stageRuntime{}, err
+	}
+	if imageID == "" {
+		return stageRuntime{}, ExitErrorf(2, "Missing base image id (set --image or dbms.image)")
+	}
+	if runOpts.Verbose {
+		fmt.Fprint(stderr, formatImageSource(imageID, source))
+	}
+
+	runtime := stageRuntime{
+		opts:  runOpts,
+		watch: req.parsed.Watch,
+	}
+	runtime.opts.ImageID = imageID
+	runtime.opts.DisableControlPrompt = usesPrepareRef(req.parsed, req.ref)
+
+	switch req.kind {
+	case "psql":
+		bound, err := bindPreparePsqlInputsFn(runOpts, req.workspaceRoot, req.cwd, req.parsed, req.ref, os.Stdin)
+		if err != nil {
+			return stageRuntime{}, err
+		}
+		runtime.cleanup = bound.cleanup
+		runtime.opts.PsqlArgs = bound.PsqlArgs
+		runtime.opts.Stdin = bound.Stdin
+		runtime.opts.PrepareKind = "psql"
+	case "lb":
+		liquibaseExec, err := resolveLiquibaseExec(cfg)
+		if err != nil {
+			return stageRuntime{}, err
+		}
+		liquibaseExecMode, err := resolveLiquibaseExecMode(cfg)
+		if err != nil {
+			return stageRuntime{}, err
+		}
+		bound, err := bindPrepareLiquibaseInputsFn(runOpts, req.workspaceRoot, req.cwd, req.parsed, req.ref, liquibaseExec, liquibaseExecMode, req.relativizeLiquibasePath)
+		if err != nil {
+			return stageRuntime{}, err
+		}
+		runtime.cleanup = bound.cleanup
+		runtime.opts.LiquibaseArgs = bound.LiquibaseArgs
+		runtime.opts.LiquibaseExec = liquibaseExec
+		runtime.opts.LiquibaseExecMode = liquibaseExecMode
+		runtime.opts.LiquibaseEnv = resolveLiquibaseEnv()
+		runtime.opts.WorkDir = bound.WorkDir
+		runtime.opts.PrepareKind = "lb"
+	default:
+		switch req.mode {
+		case stageModePlan:
+			return stageRuntime{}, ExitErrorf(2, "unsupported plan kind: %s", req.kind)
+		default:
+			return stageRuntime{}, ExitErrorf(2, "unsupported prepare kind: %s", req.kind)
+		}
+	}
+
+	if req.mode == stageModePlan {
+		runtime.opts.PlanOnly = true
+	}
+	return runtime, nil
+}
+
+func executePlanStage(stdout io.Writer, runtime stageRuntime, output string) error {
+	result, err := runPlanFn(context.Background(), runtime.opts)
+	if err != nil {
+		return finishPrepareCleanup(err, runtime.cleanup)
+	}
+	if output == "json" {
+		return finishPrepareCleanup(writeJSON(stdout, result), runtime.cleanup)
+	}
+	return finishPrepareCleanup(cli.PrintPlan(stdout, result), runtime.cleanup)
+}
+
+func executePrepareStage(w stdoutAndErr, runtime stageRuntime) (result client.PrepareJobResult, handled bool, err error) {
+	cleanupOnReturn := true
+	defer func() {
+		if cleanupOnReturn {
+			err = finishPrepareCleanup(err, runtime.cleanup)
+		}
+	}()
+
+	if !runtime.watch {
+		accepted, err := submitPrepareFn(context.Background(), runtime.opts)
+		if err != nil {
+			return client.PrepareJobResult{}, false, err
+		}
+		printPrepareJobRefs(w.stdout, accepted)
+		if runtime.opts.CompositeRun {
+			printRunSkipped(w.stdout, "prepare_not_watched")
+		}
+		return client.PrepareJobResult{}, true, nil
+	}
+
+	result, err = runPrepareFn(context.Background(), runtime.opts)
+	if err != nil {
+		var detached *cli.PrepareDetachedError
+		if errors.As(err, &detached) {
+			accepted := client.PrepareJobAccepted{
+				JobID:     detached.JobID,
+				StatusURL: "/v1/prepare-jobs/" + detached.JobID,
+				EventsURL: "/v1/prepare-jobs/" + detached.JobID + "/events",
+			}
+			printPrepareJobRefs(w.stdout, accepted)
+			if runtime.opts.CompositeRun {
+				printRunSkipped(w.stdout, "prepare_detached")
+			}
+			return client.PrepareJobResult{}, true, nil
+		}
+		return client.PrepareJobResult{}, false, err
+	}
+	return result, false, nil
+}

--- a/frontend/cli-go/internal/app/stage_pipeline_test.go
+++ b/frontend/cli-go/internal/app/stage_pipeline_test.go
@@ -1,0 +1,338 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sqlrs/cli/internal/cli"
+	"github.com/sqlrs/cli/internal/client"
+	"github.com/sqlrs/cli/internal/config"
+	"github.com/sqlrs/cli/internal/paths"
+	"github.com/sqlrs/cli/internal/refctx"
+)
+
+func TestStagePipelinePlanPsqlRendersHumanAndJSONOutputs(t *testing.T) {
+	prevBind := bindPreparePsqlInputsFn
+	bindPreparePsqlInputsFn = func(cli.PrepareOptions, string, string, prepareArgs, *refctx.Context, io.Reader) (prepareStageBinding, error) {
+		return prepareStageBinding{PsqlArgs: []string{"-c", "select 1"}}, nil
+	}
+	t.Cleanup(func() { bindPreparePsqlInputsFn = prevBind })
+
+	prevRunPlan := runPlanFn
+	runPlanCalls := 0
+	runPlanFn = func(context.Context, cli.PrepareOptions) (cli.PlanResult, error) {
+		runPlanCalls++
+		return cli.PlanResult{
+			PrepareKind:           "psql",
+			ImageID:               "img",
+			PrepareArgsNormalized: "-c select 1",
+			Tasks: []client.PlanTask{
+				{TaskID: "plan", Type: "plan", PlannerKind: "psql"},
+				{TaskID: "execute-0", Type: "state_execute", OutputStateID: "state-1"},
+			},
+		}, nil
+	}
+	t.Cleanup(func() { runPlanFn = prevRunPlan })
+
+	var human bytes.Buffer
+	if err := runPlanKindParsedWithPathMode(&human, io.Discard, cli.PrepareOptions{}, config.LoadedConfig{}, "", "", prepareArgs{
+		Image:    "img",
+		PsqlArgs: []string{"-c", "select 1"},
+	}, nil, "human", "psql", true); err != nil {
+		t.Fatalf("runPlanKindParsedWithPathMode(human): %v", err)
+	}
+	if !strings.Contains(human.String(), "Final state: state-1") {
+		t.Fatalf("unexpected human output: %q", human.String())
+	}
+
+	var jsonOut bytes.Buffer
+	if err := runPlanKindParsedWithPathMode(&jsonOut, io.Discard, cli.PrepareOptions{}, config.LoadedConfig{}, "", "", prepareArgs{
+		Image:    "img",
+		PsqlArgs: []string{"-c", "select 1"},
+	}, nil, "json", "psql", true); err != nil {
+		t.Fatalf("runPlanKindParsedWithPathMode(json): %v", err)
+	}
+	var got cli.PlanResult
+	if err := json.Unmarshal(jsonOut.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal(plan output): %v", err)
+	}
+	if got.PrepareKind != "psql" || got.ImageID != "img" {
+		t.Fatalf("unexpected json output: %+v", got)
+	}
+	if runPlanCalls != 2 {
+		t.Fatalf("runPlan calls = %d, want 2", runPlanCalls)
+	}
+}
+
+func TestStagePipelinePreparePsqlWatchRunsPrepare(t *testing.T) {
+	prevBind := bindPreparePsqlInputsFn
+	bindPreparePsqlInputsFn = func(cli.PrepareOptions, string, string, prepareArgs, *refctx.Context, io.Reader) (prepareStageBinding, error) {
+		return prepareStageBinding{PsqlArgs: []string{"-c", "select 1"}}, nil
+	}
+	t.Cleanup(func() { bindPreparePsqlInputsFn = prevBind })
+
+	prevSubmit := submitPrepareFn
+	submitPrepareFn = func(context.Context, cli.PrepareOptions) (client.PrepareJobAccepted, error) {
+		t.Fatal("submitPrepareFn should not be called for watched prepare")
+		return client.PrepareJobAccepted{}, nil
+	}
+	t.Cleanup(func() { submitPrepareFn = prevSubmit })
+
+	prevRunPrepare := runPrepareFn
+	runPrepareFn = func(_ context.Context, opts cli.PrepareOptions) (client.PrepareJobResult, error) {
+		if opts.PrepareKind != "psql" {
+			t.Fatalf("PrepareKind = %q, want %q", opts.PrepareKind, "psql")
+		}
+		if got := strings.Join(opts.PsqlArgs, " "); got != "-c select 1" {
+			t.Fatalf("PsqlArgs = %q", got)
+		}
+		return client.PrepareJobResult{DSN: "dsn"}, nil
+	}
+	t.Cleanup(func() { runPrepareFn = prevRunPrepare })
+
+	result, handled, err := prepareResultParsed(stdoutAndErr{stdout: &bytes.Buffer{}, stderr: io.Discard}, cli.PrepareOptions{}, config.LoadedConfig{}, "", "", prepareArgs{
+		Image:    "img",
+		PsqlArgs: []string{"-c", "select 1"},
+		Watch:    true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("prepareResultParsed: %v", err)
+	}
+	if handled {
+		t.Fatalf("expected handled=false")
+	}
+	if result.DSN != "dsn" {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+}
+
+func TestStagePipelinePrepareNoWatchSubmitsAndPrintsRefs(t *testing.T) {
+	prevBind := bindPreparePsqlInputsFn
+	bindPreparePsqlInputsFn = func(cli.PrepareOptions, string, string, prepareArgs, *refctx.Context, io.Reader) (prepareStageBinding, error) {
+		return prepareStageBinding{PsqlArgs: []string{"-c", "select 1"}}, nil
+	}
+	t.Cleanup(func() { bindPreparePsqlInputsFn = prevBind })
+
+	prevRunPrepare := runPrepareFn
+	runPrepareFn = func(context.Context, cli.PrepareOptions) (client.PrepareJobResult, error) {
+		t.Fatal("runPrepareFn should not be called for --no-watch")
+		return client.PrepareJobResult{}, nil
+	}
+	t.Cleanup(func() { runPrepareFn = prevRunPrepare })
+
+	prevSubmit := submitPrepareFn
+	submitPrepareFn = func(_ context.Context, opts cli.PrepareOptions) (client.PrepareJobAccepted, error) {
+		if opts.PrepareKind != "psql" {
+			t.Fatalf("PrepareKind = %q, want %q", opts.PrepareKind, "psql")
+		}
+		return client.PrepareJobAccepted{
+			JobID:     "job-1",
+			StatusURL: "/v1/prepare-jobs/job-1",
+			EventsURL: "/v1/prepare-jobs/job-1/events",
+		}, nil
+	}
+	t.Cleanup(func() { submitPrepareFn = prevSubmit })
+
+	var stdout bytes.Buffer
+	_, handled, err := prepareResultParsed(stdoutAndErr{stdout: &stdout, stderr: io.Discard}, cli.PrepareOptions{CompositeRun: true}, config.LoadedConfig{}, "", "", prepareArgs{
+		Image:          "img",
+		PsqlArgs:       []string{"-c", "select 1"},
+		Watch:          false,
+		WatchSpecified: true,
+	}, nil)
+	if err != nil {
+		t.Fatalf("prepareResultParsed: %v", err)
+	}
+	if !handled {
+		t.Fatalf("expected handled=true")
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "JOB_ID=job-1") || !strings.Contains(out, "RUN_SKIPPED=prepare_not_watched") {
+		t.Fatalf("unexpected stdout: %q", out)
+	}
+}
+
+func TestStagePipelineLiquibaseResolvesExecAndWorkDirOnce(t *testing.T) {
+	cfgDir := t.TempDir()
+	projectConfig := filepath.Join(cfgDir, ".sqlrs", "config.yaml")
+	if err := os.MkdirAll(filepath.Dir(projectConfig), 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(projectConfig, []byte("liquibase:\n  exec: liquibase.cmd\n  exec_mode: windows-bat\n"), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	prevBind := bindPrepareLiquibaseInputsFn
+	bindCalls := 0
+	bindPrepareLiquibaseInputsFn = func(_ cli.PrepareOptions, workspaceRoot string, cwd string, parsed prepareArgs, _ *refctx.Context, exec string, execMode string, relativizePaths bool) (prepareStageBinding, error) {
+		bindCalls++
+		if exec != "liquibase.cmd" || execMode != "windows-bat" {
+			t.Fatalf("unexpected liquibase exec settings: %q %q", exec, execMode)
+		}
+		if !relativizePaths {
+			t.Fatal("expected relativizePaths=true")
+		}
+		if workspaceRoot != cfgDir || cwd != cfgDir {
+			t.Fatalf("unexpected workspace/cwd: %q %q", workspaceRoot, cwd)
+		}
+		if got := strings.Join(parsed.PsqlArgs, " "); got != "update --changelog-file master.xml" {
+			t.Fatalf("unexpected parsed args: %q", got)
+		}
+		return prepareStageBinding{
+			LiquibaseArgs: []string{"update", "--changelog-file", "master.xml"},
+			WorkDir:       cwd,
+		}, nil
+	}
+	t.Cleanup(func() { bindPrepareLiquibaseInputsFn = prevBind })
+
+	prevRunPlan := runPlanFn
+	runPlanFn = func(_ context.Context, opts cli.PrepareOptions) (cli.PlanResult, error) {
+		if opts.LiquibaseExec != "liquibase.cmd" || opts.LiquibaseExecMode != "windows-bat" {
+			t.Fatalf("unexpected options: %+v", opts)
+		}
+		if opts.WorkDir != cfgDir {
+			t.Fatalf("WorkDir = %q, want %q", opts.WorkDir, cfgDir)
+		}
+		return cli.PlanResult{
+			PrepareKind:           "lb",
+			ImageID:               "img",
+			PrepareArgsNormalized: "update --changelog-file master.xml",
+			Tasks: []client.PlanTask{
+				{TaskID: "plan", Type: "plan", PlannerKind: "lb"},
+				{TaskID: "execute-0", Type: "state_execute", OutputStateID: "state-1"},
+			},
+		}, nil
+	}
+	t.Cleanup(func() { runPlanFn = prevRunPlan })
+
+	err := runPlanKindParsedWithPathMode(&bytes.Buffer{}, io.Discard, cli.PrepareOptions{}, config.LoadedConfig{
+		ProjectConfigPath: projectConfig,
+		Paths:             paths.Dirs{ConfigDir: t.TempDir()},
+	}, cfgDir, cfgDir, prepareArgs{
+		Image:    "img",
+		PsqlArgs: []string{"update", "--changelog-file", "master.xml"},
+	}, nil, "json", "lb", true)
+	if err != nil {
+		t.Fatalf("runPlanKindParsedWithPathMode: %v", err)
+	}
+	if bindCalls != 1 {
+		t.Fatalf("bindPrepareLiquibaseInputs calls = %d, want 1", bindCalls)
+	}
+}
+
+func TestStagePipelineRejectsPlanWatchFlagsBeforeInvocation(t *testing.T) {
+	prevBind := bindPreparePsqlInputsFn
+	bindPreparePsqlInputsFn = func(cli.PrepareOptions, string, string, prepareArgs, *refctx.Context, io.Reader) (prepareStageBinding, error) {
+		t.Fatal("bindPreparePsqlInputsFn should not be called")
+		return prepareStageBinding{}, nil
+	}
+	t.Cleanup(func() { bindPreparePsqlInputsFn = prevBind })
+
+	prevRunPlan := runPlanFn
+	runPlanFn = func(context.Context, cli.PrepareOptions) (cli.PlanResult, error) {
+		t.Fatal("runPlanFn should not be called")
+		return cli.PlanResult{}, nil
+	}
+	t.Cleanup(func() { runPlanFn = prevRunPlan })
+
+	err := runPlanKindParsedWithPathMode(&bytes.Buffer{}, io.Discard, cli.PrepareOptions{}, config.LoadedConfig{}, "", "", prepareArgs{
+		Image:          "img",
+		PsqlArgs:       []string{"-c", "select 1"},
+		Watch:          false,
+		WatchSpecified: true,
+	}, nil, "json", "psql", true)
+	if err == nil || !strings.Contains(err.Error(), "plan does not support --watch/--no-watch") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestStagePipelineRejectsLiquibaseWithoutCommand(t *testing.T) {
+	prevBind := bindPrepareLiquibaseInputsFn
+	bindPrepareLiquibaseInputsFn = func(cli.PrepareOptions, string, string, prepareArgs, *refctx.Context, string, string, bool) (prepareStageBinding, error) {
+		t.Fatal("bindPrepareLiquibaseInputsFn should not be called")
+		return prepareStageBinding{}, nil
+	}
+	t.Cleanup(func() { bindPrepareLiquibaseInputsFn = prevBind })
+
+	_, _, err := prepareResultLiquibaseParsedWithPathMode(stdoutAndErr{stdout: &bytes.Buffer{}, stderr: io.Discard}, cli.PrepareOptions{}, config.LoadedConfig{}, "", "", prepareArgs{
+		Image: "img",
+		Watch: true,
+	}, nil, true)
+	if err == nil || !strings.Contains(err.Error(), "liquibase command is required") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAliasBackedPlanAndPrepareReuseSharedStagePipeline(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "demo.prep.s9s.yaml"), []byte("kind: psql\nimage: img\nargs:\n  - -c\n  - select 1\n"), 0o600); err != nil {
+		t.Fatalf("write alias: %v", err)
+	}
+
+	prevBind := bindPreparePsqlInputsFn
+	var seen []string
+	bindPreparePsqlInputsFn = func(_ cli.PrepareOptions, workspaceRoot string, cwd string, parsed prepareArgs, _ *refctx.Context, _ io.Reader) (prepareStageBinding, error) {
+		if workspaceRoot != root || cwd != root {
+			t.Fatalf("unexpected workspace/cwd: %q %q", workspaceRoot, cwd)
+		}
+		seen = append(seen, parsed.Image+"|"+strings.Join(parsed.PsqlArgs, " "))
+		return prepareStageBinding{PsqlArgs: parsed.PsqlArgs}, nil
+	}
+	t.Cleanup(func() { bindPreparePsqlInputsFn = prevBind })
+
+	prevRunPrepare := runPrepareFn
+	runPrepareFn = func(_ context.Context, opts cli.PrepareOptions) (client.PrepareJobResult, error) {
+		if opts.PrepareKind != "psql" {
+			t.Fatalf("unexpected prepare kind: %q", opts.PrepareKind)
+		}
+		return client.PrepareJobResult{DSN: "dsn"}, nil
+	}
+	t.Cleanup(func() { runPrepareFn = prevRunPrepare })
+
+	prevRunPlan := runPlanFn
+	runPlanFn = func(_ context.Context, opts cli.PrepareOptions) (cli.PlanResult, error) {
+		if opts.PrepareKind != "psql" || !opts.PlanOnly {
+			t.Fatalf("unexpected plan opts: %+v", opts)
+		}
+		return cli.PlanResult{
+			PrepareKind:           "psql",
+			ImageID:               "img",
+			PrepareArgsNormalized: "-c select 1",
+			Tasks: []client.PlanTask{
+				{TaskID: "plan", Type: "plan", PlannerKind: "psql"},
+				{TaskID: "execute-0", Type: "state_execute", OutputStateID: "state-1"},
+			},
+		}, nil
+	}
+	t.Cleanup(func() { runPlanFn = prevRunPlan })
+
+	opts := cli.GlobalOptions{}
+	configure := func(deps *runnerDeps) {
+		deps.getwd = func() (string, error) { return root, nil }
+		deps.resolveCommandContext = func(string, cli.GlobalOptions) (commandContext, error) {
+			return testCommandContext(root, "json", false), nil
+		}
+	}
+
+	if err := runWithParsedCommands(t, opts, []cli.Command{{Name: "prepare", Args: []string{"demo"}}}, configure); err != nil {
+		t.Fatalf("prepare alias run: %v", err)
+	}
+	if err := runWithParsedCommands(t, opts, []cli.Command{{Name: "plan", Args: []string{"demo"}}}, configure); err != nil {
+		t.Fatalf("plan alias run: %v", err)
+	}
+
+	if len(seen) != 2 {
+		t.Fatalf("bindPreparePsqlInputs calls = %d, want 2", len(seen))
+	}
+	for _, got := range seen {
+		if got != "img|-c select 1" {
+			t.Fatalf("unexpected bound alias args: %q", got)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

This PR implements `PR4` from the CLI maintainability plan by unifying the
duplicated `plan` / `prepare` orchestration in `frontend/cli-go/internal/app`
behind one shared package-local stage pipeline.

The change keeps the public CLI contract intact while reducing duplication
across:
- image resolution
- kind-specific binding
- terminal invocation
- cleanup handling

It also records the accepted pipeline boundary in ADR/design docs and updates
the roadmap status to reflect the new maintainability slice.

## What Changed

### Shared stage pipeline in `internal/app`

- Added a shared `stage_pipeline.go` internal boundary for prepare-oriented
  command execution.
- Moved common `plan` / `prepare` orchestration into one request/runtime flow:
  - mode selection (`plan` vs `prepare`)
  - image/config resolution
  - `psql` / Liquibase binding
  - terminal action dispatch
  - cleanup finalization
- Kept mode-specific behavior only where the commands genuinely differ:
  - `plan` renders plan output
  - `prepare` runs watch/no-watch submit flows and DSN/job-ref rendering

### Thin command facades

- Simplified `frontend/cli-go/internal/app/plan.go`
- Simplified `frontend/cli-go/internal/app/prepare.go`

Both files now delegate the shared orchestration to the new internal pipeline
instead of maintaining separate copies of the same flow.

### Tests

- Added focused regression coverage in
  `frontend/cli-go/internal/app/stage_pipeline_test.go`
- Covered:
  - human vs JSON plan rendering
  - watched prepare execution
  - `--no-watch` submit flow
  - Liquibase exec/workdir wiring
  - early validation for unsupported plan watch flags
  - early validation for missing Liquibase commands
  - alias-backed reuse of the shared pipeline

### Docs

- Added ADR:
  - `docs/adr/2026-04-20-plan-prepare-stage-pipeline-shape.md`
- Updated architecture docs:
  - `docs/architecture/cli-maintainability-refactor.md`
  - `docs/architecture/cli-maintainability-refactor.RU.md`
- Updated roadmap status:
  - `docs/roadmap.md`
  - `docs/roadmap.RU.md`

## Behavior

No user-facing CLI behavior changes are intended in this PR.

The refactor preserves:
- existing `plan` / `prepare` syntax
- watch and no-watch behavior
- alias-backed `plan` / `prepare` flows
- ref-backed prepare handling
- output and exit-code expectations

## Testing

Validated locally after the refactor; the test suite is green.