### PR TITLE
Feature/zfs and btrfs benchmark

### DIFF
--- a/.github/workflows/fs-benchmark.yml
+++ b/.github/workflows/fs-benchmark.yml
@@ -1,0 +1,182 @@
+name: fs-benchmark
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main, feature/zfs-snapshotting]
+    paths:
+      - backend/local-engine-go/internal/snapshot/**
+      - backend/local-engine-go/internal/prepare/**
+      - .github/workflows/fs-benchmark.yml
+  pull_request:
+    paths:
+      - backend/local-engine-go/internal/snapshot/**
+      - backend/local-engine-go/internal/prepare/**
+      - .github/workflows/fs-benchmark.yml
+
+jobs:
+  snapshot-benchmark:
+    name: Snapshot FS Benchmark (ZFS vs BTRFS)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/local-engine-go/go.mod
+
+      - name: Install ZFS and BTRFS tools
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y zfsutils-linux btrfs-progs
+
+      - name: Set up loop devices
+        run: |
+          fallocate -l 4G /tmp/zfs.img
+          ZFS_LOOP=$(sudo losetup -f /tmp/zfs.img --show)
+          echo "ZFS_LOOP=$ZFS_LOOP" >> "$GITHUB_ENV"
+
+          fallocate -l 4G /tmp/btrfs.img
+          BTRFS_LOOP=$(sudo losetup -f /tmp/btrfs.img --show)
+          echo "BTRFS_LOOP=$BTRFS_LOOP" >> "$GITHUB_ENV"
+
+      - name: Create ZFS pool and dataset
+        run: |
+          sudo modprobe zfs || true
+          sudo zpool create taidon-bench "$ZFS_LOOP"
+          sudo zfs create -o mountpoint=/mnt/zfs-bench taidon-bench/work
+          sudo chmod 777 /mnt/zfs-bench
+          echo "BENCH_ZFS_ROOT=/mnt/zfs-bench" >> "$GITHUB_ENV"
+
+      - name: Create BTRFS filesystem
+        run: |
+          sudo mkfs.btrfs "$BTRFS_LOOP"
+          sudo mkdir -p /mnt/btrfs-bench
+          sudo mount "$BTRFS_LOOP" /mnt/btrfs-bench
+          sudo chmod 777 /mnt/btrfs-bench
+          echo "BENCH_BTRFS_ROOT=/mnt/btrfs-bench" >> "$GITHUB_ENV"
+
+      - name: Build benchmark binary
+        working-directory: backend/local-engine-go
+        run: go test -c -o /tmp/snapshot-bench ./internal/snapshot/
+
+      - name: Run benchmarks
+        run: |
+          sudo -E /tmp/snapshot-bench \
+            -test.run='^$' \
+            -test.bench='Benchmark(Zfs|Btrfs)(Cold|Warm)Start' \
+            -test.benchtime=5x \
+            -test.benchmem \
+            -test.v \
+            2>&1 | tee /tmp/bench-raw.txt
+          echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_ENV"
+
+      - name: Upload raw benchmark output
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-raw-output
+          path: /tmp/bench-raw.txt
+          if-no-files-found: ignore
+
+      - name: Write Step Summary
+        if: always()
+        run: |
+          python3 - << 'EOF'
+          import re, os, sys
+
+          raw_file = "/tmp/bench-raw.txt"
+          if not os.path.exists(raw_file):
+              print("No benchmark output found.", file=sys.stderr)
+              sys.exit(0)
+
+          with open(raw_file) as f:
+              raw = f.read()
+
+          results = {}
+          for line in raw.splitlines():
+              m = re.match(r'Benchmark(\w+)-\d+\s+(\d+)\s+([\d.]+)\s+ns/op', line)
+              if m:
+                  results[m.group(1)] = {"n": int(m.group(2)), "ns": float(m.group(3))}
+
+          skipped = {}
+          for line in raw.splitlines():
+              m = re.match(r'---\s+SKIP:\s+Benchmark(\w+)', line)
+              if m:
+                  skipped[m.group(1)] = True
+
+          def fmt_time(ns):
+              if ns >= 1e9:
+                  return f"{ns/1e9:.2f} с"
+              if ns >= 1e6:
+                  return f"{ns/1e6:.1f} мс"
+              if ns >= 1e3:
+                  return f"{ns/1e3:.1f} мкс"
+              return f"{ns:.0f} нс"
+
+          def speedup(cold_ns, warm_ns):
+              if warm_ns and warm_ns > 0:
+                  return f"{cold_ns/warm_ns:.1f}×"
+              return "—"
+
+          lines = []
+          lines.append("## Benchmark: ZFS vs BTRFS — Snapshot Operations\n")
+          lines.append(
+              "**Сценарии**: холодный старт (создание датасета + запись 100 МБ + снапшот) "
+              "и тёплый старт (клонирование готового датасета).  "
+          )
+          lines.append("**Данные**: 100 файлов × 1 МБ = 100 МБ\n")
+
+          benchmarks = [
+              ("ZfsColdStart",   "ZFS",   "Холодный"),
+              ("ZfsWarmStart",   "ZFS",   "Тёплый"),
+              ("BtrfsColdStart", "BTRFS", "Холодный"),
+              ("BtrfsWarmStart", "BTRFS", "Тёплый"),
+          ]
+
+          lines.append("| Файловая система | Сценарий | Итерации | Время/оп |")
+          lines.append("|-----------------|----------|----------|----------|")
+          for key, fs, scenario in benchmarks:
+              if key in results:
+                  r = results[key]
+                  lines.append(f"| {fs} | {scenario} старт | {r['n']} | {fmt_time(r['ns'])} |")
+              elif key in skipped:
+                  lines.append(f"| {fs} | {scenario} старт | — | пропущен |")
+              else:
+                  lines.append(f"| {fs} | {scenario} старт | — | нет данных |")
+
+          lines.append("")
+          lines.append("### Ускорение тёплого старта относительно холодного\n")
+          lines.append("| Файловая система | Холодный | Тёплый | Ускорение |")
+          lines.append("|-----------------|----------|--------|-----------|")
+          for fs_key, fs_name in [("Zfs", "ZFS"), ("Btrfs", "BTRFS")]:
+              cold = results.get(f"{fs_key}ColdStart")
+              warm = results.get(f"{fs_key}WarmStart")
+              cold_s = fmt_time(cold["ns"]) if cold else "—"
+              warm_s = fmt_time(warm["ns"]) if warm else "—"
+              sp = speedup(cold["ns"], warm["ns"]) if cold and warm else "—"
+              lines.append(f"| {fs_name} | {cold_s} | {warm_s} | {sp} |")
+
+          lines.append("")
+          lines.append("<details>")
+          lines.append("<summary>Полный вывод <code>go test -bench</code></summary>\n")
+          lines.append("```")
+          lines.append(raw.strip())
+          lines.append("```")
+          lines.append("</details>")
+
+          summary = "\n".join(lines) + "\n"
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
+              f.write(summary)
+          print(summary)
+          EOF
+
+      - name: Cleanup
+        if: always()
+        run: |
+          sudo umount /mnt/btrfs-bench 2>/dev/null || true
+          sudo zpool destroy taidon-bench 2>/dev/null || true
+          sudo losetup -d "$ZFS_LOOP" 2>/dev/null || true
+          sudo losetup -d "$BTRFS_LOOP" 2>/dev/null || true

--- a/.github/workflows/fs-benchmark.yml
+++ b/.github/workflows/fs-benchmark.yml
@@ -112,12 +112,12 @@ jobs:
 
           def fmt_time(ns):
               if ns >= 1e9:
-                  return f"{ns/1e9:.2f} с"
+                  return f"{ns/1e9:.2f} s"
               if ns >= 1e6:
-                  return f"{ns/1e6:.1f} мс"
+                  return f"{ns/1e6:.1f} ms"
               if ns >= 1e3:
-                  return f"{ns/1e3:.1f} мкс"
-              return f"{ns:.0f} нс"
+                  return f"{ns/1e3:.1f} µs"
+              return f"{ns:.0f} ns"
 
           def speedup(cold_ns, warm_ns):
               if warm_ns and warm_ns > 0:
@@ -127,33 +127,33 @@ jobs:
           lines = []
           lines.append("## Benchmark: ZFS vs BTRFS — Snapshot Operations\n")
           lines.append(
-              "**Сценарии**: холодный старт (создание датасета + запись 100 МБ + снапшот) "
-              "и тёплый старт (клонирование готового датасета).  "
+              "**Scenarios**: cold start (create dataset + write 100 MB + snapshot) "
+              "and warm start (clone existing dataset).  "
           )
-          lines.append("**Данные**: 100 файлов × 1 МБ = 100 МБ\n")
+          lines.append("**Data**: 100 files × 1 MB = 100 MB\n")
 
           benchmarks = [
-              ("ZfsColdStart",   "ZFS",   "Холодный"),
-              ("ZfsWarmStart",   "ZFS",   "Тёплый"),
-              ("BtrfsColdStart", "BTRFS", "Холодный"),
-              ("BtrfsWarmStart", "BTRFS", "Тёплый"),
+              ("ZfsColdStart",   "ZFS",   "Cold"),
+              ("ZfsWarmStart",   "ZFS",   "Warm"),
+              ("BtrfsColdStart", "BTRFS", "Cold"),
+              ("BtrfsWarmStart", "BTRFS", "Warm"),
           ]
 
-          lines.append("| Файловая система | Сценарий | Итерации | Время/оп |")
-          lines.append("|-----------------|----------|----------|----------|")
+          lines.append("| Filesystem | Scenario | Iterations | Time/op |")
+          lines.append("|------------|----------|------------|---------|")
           for key, fs, scenario in benchmarks:
               if key in results:
                   r = results[key]
-                  lines.append(f"| {fs} | {scenario} старт | {r['n']} | {fmt_time(r['ns'])} |")
+                  lines.append(f"| {fs} | {scenario} start | {r['n']} | {fmt_time(r['ns'])} |")
               elif key in skipped:
-                  lines.append(f"| {fs} | {scenario} старт | — | пропущен |")
+                  lines.append(f"| {fs} | {scenario} start | — | skipped |")
               else:
-                  lines.append(f"| {fs} | {scenario} старт | — | нет данных |")
+                  lines.append(f"| {fs} | {scenario} start | — | no data |")
 
           lines.append("")
-          lines.append("### Ускорение тёплого старта относительно холодного\n")
-          lines.append("| Файловая система | Холодный | Тёплый | Ускорение |")
-          lines.append("|-----------------|----------|--------|-----------|")
+          lines.append("### Warm start speedup over cold start\n")
+          lines.append("| Filesystem | Cold start | Warm start | Speedup |")
+          lines.append("|------------|------------|------------|---------|")
           for fs_key, fs_name in [("Zfs", "ZFS"), ("Btrfs", "BTRFS")]:
               cold = results.get(f"{fs_key}ColdStart")
               warm = results.get(f"{fs_key}WarmStart")
@@ -164,7 +164,7 @@ jobs:
 
           lines.append("")
           lines.append("<details>")
-          lines.append("<summary>Полный вывод <code>go test -bench</code></summary>\n")
+          lines.append("<summary>Full <code>go test -bench</code> output</summary>\n")
           lines.append("```")
           lines.append(raw.strip())
           lines.append("```")

--- a/.github/workflows/fs-benchmark.yml
+++ b/.github/workflows/fs-benchmark.yml
@@ -18,6 +18,9 @@ jobs:
   snapshot-benchmark:
     name: Snapshot FS Benchmark (ZFS vs BTRFS)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -170,8 +173,42 @@ jobs:
           summary = "\n".join(lines) + "\n"
           with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as f:
               f.write(summary)
+          with open("/tmp/bench-comment.md", "w") as f:
+              f.write(summary)
           print(summary)
           EOF
+
+      - name: Find existing benchmark comment
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: peter-evans/find-comment@v3
+        id: bench-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: "Benchmark: ZFS vs BTRFS"
+
+      - name: Post benchmark comment on PR
+        if: always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.bench-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body-file: /tmp/bench-comment.md
+
+      - name: Post benchmark comment on main
+        if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs')
+            if (!fs.existsSync('/tmp/bench-comment.md')) { return }
+            const body = fs.readFileSync('/tmp/bench-comment.md', 'utf8')
+            await github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body,
+            })
 
       - name: Cleanup
         if: always()

--- a/backend/local-engine-go/internal/snapshot/bench_fs_linux_test.go
+++ b/backend/local-engine-go/internal/snapshot/bench_fs_linux_test.go
@@ -48,6 +48,7 @@ func BenchmarkZfsWarmStart(b *testing.B) {
 	benchWriteTestData(b, srcDir)
 	b.Cleanup(func() {
 		_ = mgr.Destroy(context.Background(), srcDir)
+		_ = os.Remove(srcDir) // ZFS leaves the mount-point dir behind after destroy
 	})
 
 	b.SetBytes(int64(benchFileCount) * benchFileSize)
@@ -63,6 +64,7 @@ func BenchmarkZfsWarmStart(b *testing.B) {
 		if err := result.Cleanup(); err != nil {
 			b.Fatalf("Cleanup iteration %d: %v", i, err)
 		}
+		_ = os.Remove(destDir)
 		b.StartTimer()
 	}
 }
@@ -96,7 +98,9 @@ func BenchmarkZfsColdStart(b *testing.B) {
 
 		b.StopTimer()
 		_ = mgr.Destroy(ctx, snapDir)
+		_ = os.Remove(snapDir)
 		_ = mgr.Destroy(ctx, srcDir)
+		_ = os.Remove(srcDir)
 		b.StartTimer()
 	}
 }
@@ -119,6 +123,7 @@ func BenchmarkBtrfsWarmStart(b *testing.B) {
 	benchWriteTestData(b, srcDir)
 	b.Cleanup(func() {
 		_ = mgr.Destroy(context.Background(), srcDir)
+		_ = os.Remove(srcDir) // btrfs subvolume delete leaves the mount point dir
 	})
 
 	b.SetBytes(int64(benchFileCount) * benchFileSize)
@@ -134,6 +139,7 @@ func BenchmarkBtrfsWarmStart(b *testing.B) {
 		if err := result.Cleanup(); err != nil {
 			b.Fatalf("Cleanup iteration %d: %v", i, err)
 		}
+		_ = os.Remove(destDir)
 		b.StartTimer()
 	}
 }
@@ -167,7 +173,9 @@ func BenchmarkBtrfsColdStart(b *testing.B) {
 
 		b.StopTimer()
 		_ = mgr.Destroy(ctx, snapDir)
+		_ = os.Remove(snapDir)
 		_ = mgr.Destroy(ctx, srcDir)
+		_ = os.Remove(srcDir)
 		b.StartTimer()
 	}
 }

--- a/backend/local-engine-go/internal/snapshot/bench_fs_linux_test.go
+++ b/backend/local-engine-go/internal/snapshot/bench_fs_linux_test.go
@@ -1,0 +1,173 @@
+//go:build linux
+
+package snapshot
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Simulated PostgreSQL-like data directory: 100 files × 1 MiB = 100 MiB total.
+const benchFileCount = 100
+const benchFileSize = 1 << 20 // 1 MiB
+
+// benchWriteTestData fills dir with benchFileCount files of benchFileSize bytes.
+func benchWriteTestData(b *testing.B, dir string) {
+	b.Helper()
+	payload := make([]byte, benchFileSize)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	for i := 0; i < benchFileCount; i++ {
+		p := filepath.Join(dir, fmt.Sprintf("data%04d.bin", i))
+		if err := os.WriteFile(p, payload, 0o600); err != nil {
+			b.Fatalf("benchWriteTestData: write %s: %v", p, err)
+		}
+	}
+}
+
+// BenchmarkZfsWarmStart measures the time to clone an existing ZFS dataset (warm start:
+// state is already prepared, just clone for the next run).
+// Requires BENCH_ZFS_ROOT pointing to a ZFS dataset mountpoint (e.g. /mnt/zfs-bench).
+func BenchmarkZfsWarmStart(b *testing.B) {
+	root := os.Getenv("BENCH_ZFS_ROOT")
+	if root == "" {
+		b.Skip("BENCH_ZFS_ROOT not set; skipping ZFS warm-start benchmark")
+	}
+
+	ctx := context.Background()
+	mgr := zfsManager{runner: execRunner{}}
+	srcDir := filepath.Join(root, "warm-src")
+
+	if err := mgr.EnsureDataset(ctx, srcDir); err != nil {
+		b.Fatalf("EnsureDataset: %v", err)
+	}
+	benchWriteTestData(b, srcDir)
+	b.Cleanup(func() {
+		_ = mgr.Destroy(context.Background(), srcDir)
+	})
+
+	b.SetBytes(int64(benchFileCount) * benchFileSize)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		destDir := filepath.Join(root, fmt.Sprintf("warm-clone-%d", i))
+		result, err := mgr.Clone(ctx, srcDir, destDir)
+		if err != nil {
+			b.Fatalf("Clone iteration %d: %v", i, err)
+		}
+		b.StopTimer()
+		if err := result.Cleanup(); err != nil {
+			b.Fatalf("Cleanup iteration %d: %v", i, err)
+		}
+		b.StartTimer()
+	}
+}
+
+// BenchmarkZfsColdStart measures the full cold-start pipeline on ZFS:
+// create dataset → write data (simulate DB init) → snapshot.
+// Requires BENCH_ZFS_ROOT.
+func BenchmarkZfsColdStart(b *testing.B) {
+	root := os.Getenv("BENCH_ZFS_ROOT")
+	if root == "" {
+		b.Skip("BENCH_ZFS_ROOT not set; skipping ZFS cold-start benchmark")
+	}
+
+	ctx := context.Background()
+	mgr := zfsManager{runner: execRunner{}}
+
+	b.SetBytes(int64(benchFileCount) * benchFileSize)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		srcDir := filepath.Join(root, fmt.Sprintf("cold-src-%d", i))
+		snapDir := filepath.Join(root, fmt.Sprintf("cold-snap-%d", i))
+
+		if err := mgr.EnsureDataset(ctx, srcDir); err != nil {
+			b.Fatalf("EnsureDataset iter %d: %v", i, err)
+		}
+		benchWriteTestData(b, srcDir)
+		if err := mgr.Snapshot(ctx, srcDir, snapDir); err != nil {
+			b.Fatalf("Snapshot iter %d: %v", i, err)
+		}
+
+		b.StopTimer()
+		_ = mgr.Destroy(ctx, snapDir)
+		_ = mgr.Destroy(ctx, srcDir)
+		b.StartTimer()
+	}
+}
+
+// BenchmarkBtrfsWarmStart measures the time to clone an existing BTRFS subvolume (warm start).
+// Requires BENCH_BTRFS_ROOT pointing to a BTRFS-mounted directory (e.g. /mnt/btrfs-bench).
+func BenchmarkBtrfsWarmStart(b *testing.B) {
+	root := os.Getenv("BENCH_BTRFS_ROOT")
+	if root == "" {
+		b.Skip("BENCH_BTRFS_ROOT not set; skipping BTRFS warm-start benchmark")
+	}
+
+	ctx := context.Background()
+	mgr := btrfsManager{runner: execRunner{}}
+	srcDir := filepath.Join(root, "warm-src")
+
+	if err := mgr.EnsureSubvolume(ctx, srcDir); err != nil {
+		b.Fatalf("EnsureSubvolume: %v", err)
+	}
+	benchWriteTestData(b, srcDir)
+	b.Cleanup(func() {
+		_ = mgr.Destroy(context.Background(), srcDir)
+	})
+
+	b.SetBytes(int64(benchFileCount) * benchFileSize)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		destDir := filepath.Join(root, fmt.Sprintf("warm-clone-%d", i))
+		result, err := mgr.Clone(ctx, srcDir, destDir)
+		if err != nil {
+			b.Fatalf("Clone iteration %d: %v", i, err)
+		}
+		b.StopTimer()
+		if err := result.Cleanup(); err != nil {
+			b.Fatalf("Cleanup iteration %d: %v", i, err)
+		}
+		b.StartTimer()
+	}
+}
+
+// BenchmarkBtrfsColdStart measures the full cold-start pipeline on BTRFS:
+// create subvolume → write data → snapshot.
+// Requires BENCH_BTRFS_ROOT.
+func BenchmarkBtrfsColdStart(b *testing.B) {
+	root := os.Getenv("BENCH_BTRFS_ROOT")
+	if root == "" {
+		b.Skip("BENCH_BTRFS_ROOT not set; skipping BTRFS cold-start benchmark")
+	}
+
+	ctx := context.Background()
+	mgr := btrfsManager{runner: execRunner{}}
+
+	b.SetBytes(int64(benchFileCount) * benchFileSize)
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		srcDir := filepath.Join(root, fmt.Sprintf("cold-src-%d", i))
+		snapDir := filepath.Join(root, fmt.Sprintf("cold-snap-%d", i))
+
+		if err := mgr.EnsureSubvolume(ctx, srcDir); err != nil {
+			b.Fatalf("EnsureSubvolume iter %d: %v", i, err)
+		}
+		benchWriteTestData(b, srcDir)
+		if err := mgr.Snapshot(ctx, srcDir, snapDir); err != nil {
+			b.Fatalf("Snapshot iter %d: %v", i, err)
+		}
+
+		b.StopTimer()
+		_ = mgr.Destroy(ctx, snapDir)
+		_ = mgr.Destroy(ctx, srcDir)
+		b.StartTimer()
+	}
+}


### PR DESCRIPTION
# Summary

Добавлен CI-бенчмарк, сравнивающий производительность ZFS и BTRFS в сценариях холодного и тёплого старта.

## Changes
- `.github/workflows/fs-benchmark.yml` — новый workflow: создаёт loop-устройства с ZFS и BTRFS, прогоняет бенчмарки и публикует таблицу результатов в комментарий к PR/коммиту
- `internal/snapshot/bench_fs_linux_test.go` — Go-бенчмарки `BenchmarkZfs/BtrfsColdStart` (создание датасета + 100 МБ данных + снапшот) и `BenchmarkZfs/BtrfsWarmStart` (клонирование готового датасета); управляются через env `BENCH_ZFS_ROOT` / `BENCH_BTRFS_ROOT`

## Testing
- [x] `backend/*` tests — бенчмарки запускаются в CI на реальных ZFS/BTRFS loop-устройствах через `fs-benchmark` workflow; результаты публикуются в комментарий к PR

## Related issues
