### PR TITLE
chore: update Go toolchain to 1.25

### DIFF
--- a/backend/local-engine-go/go.mod
+++ b/backend/local-engine-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/sqlrs/engine-local
 
-go 1.22
+go 1.25
 
 require modernc.org/sqlite v1.29.0
 

--- a/examples/flights/queries.sql
+++ b/examples/flights/queries.sql
@@ -1,5 +1,8 @@
 \echo 'PostgresPro demo sanity checks'
-select count(*) as airports from airports;
+\connect demo
+SET search_path = bookings, pg_catalog;
+
+select count(*) as airports from bookings.airports;
 select count(*) as flights from flights;
 
 select flight_no, scheduled_departure, scheduled_arrival

--- a/frontend/cli-go.md
+++ b/frontend/cli-go.md
@@ -20,7 +20,7 @@ Non-goals (for now):
 
 ## 1. Tech constraints
 
-- Language: Go (latest stable supported by CI; prefer Go 1.22+)
+- Language: Go 1.25+ (latest stable supported by CI)
 - Dependencies: keep minimal; prefer stdlib for HTTP/JSON.
 - Config file format: YAML (requires a YAML lib; choose one and use only it)
 - Cross-platform: Windows, Linux, macOS

--- a/frontend/cli-go/go.mod
+++ b/frontend/cli-go/go.mod
@@ -1,6 +1,6 @@
 module github.com/sqlrs/cli
 
-go 1.22
+go 1.25
 
 require (
 	golang.org/x/sys v0.20.0

--- a/frontend/cli-go/internal/alias/create.go
+++ b/frontend/cli-go/internal/alias/create.go
@@ -222,12 +222,12 @@ func rewriteCreateArgs(class Class, kind string, args []string, workspaceRoot st
 		switch kind {
 		case "psql":
 			if issues := inputpsql.ValidateArgs(args, inputset.NewWorkspaceResolver(workspaceRoot, cwd, nil), inputset.OSFileSystem{}); len(issues) > 0 {
-				return nil, fmt.Errorf(issues[0].Message)
+				return nil, fmt.Errorf("%s", issues[0].Message)
 			}
 			return relativizePsqlCreateArgs(args, workspaceRoot, cwd, aliasDir)
 		case "lb":
 			if issues := inputliquibase.ValidateArgs(args, inputset.NewWorkspaceResolver(workspaceRoot, cwd, nil), inputset.OSFileSystem{}); len(issues) > 0 {
-				return nil, fmt.Errorf(issues[0].Message)
+				return nil, fmt.Errorf("%s", issues[0].Message)
 			}
 			return relativizeLiquibaseCreateArgs(args, workspaceRoot, cwd, aliasDir)
 		default:
@@ -237,12 +237,12 @@ func rewriteCreateArgs(class Class, kind string, args []string, workspaceRoot st
 		switch kind {
 		case runkind.KindPsql:
 			if issues := inputpsql.ValidateArgs(args, inputset.NewWorkspaceResolver(workspaceRoot, cwd, nil), inputset.OSFileSystem{}); len(issues) > 0 {
-				return nil, fmt.Errorf(issues[0].Message)
+				return nil, fmt.Errorf("%s", issues[0].Message)
 			}
 			return relativizePsqlCreateArgs(args, workspaceRoot, cwd, aliasDir)
 		case runkind.KindPgbench:
 			if issues := inputpgbench.ValidateArgs(args, inputset.NewWorkspaceResolver(workspaceRoot, cwd, nil), inputset.OSFileSystem{}); len(issues) > 0 {
-				return nil, fmt.Errorf(issues[0].Message)
+				return nil, fmt.Errorf("%s", issues[0].Message)
 			}
 			return relativizePgbenchCreateArgs(args, workspaceRoot, cwd, aliasDir)
 		default:

--- a/frontend/cli-go/internal/app/alias_command.go
+++ b/frontend/cli-go/internal/app/alias_command.go
@@ -142,7 +142,7 @@ func runAliasCommand(stdout io.Writer, cmdCtx commandContext, args []string) err
 	case "ls":
 		entries, err := alias.Scan(scanOpts)
 		if err != nil {
-			return ExitErrorf(2, err.Error())
+			return ExitErrorf(2, "%s", err.Error())
 		}
 		if cmdCtx.output == "json" {
 			return writeJSON(stdout, entries)
@@ -176,7 +176,7 @@ func runAliasCheck(cmdCtx commandContext, scanOpts alias.ScanOptions, cmd aliasC
 	if cmd.Ref == "" {
 		report, err := alias.CheckScan(scanOpts)
 		if err != nil {
-			return alias.CheckReport{}, ExitErrorf(2, err.Error())
+			return alias.CheckReport{}, ExitErrorf(2, "%s", err.Error())
 		}
 		return report, nil
 	}
@@ -188,7 +188,7 @@ func runAliasCheck(cmdCtx commandContext, scanOpts alias.ScanOptions, cmd aliasC
 		Class:         selectedSingleAliasClass(cmd),
 	})
 	if err != nil {
-		return alias.CheckReport{}, ExitErrorf(2, err.Error())
+		return alias.CheckReport{}, ExitErrorf(2, "%s", err.Error())
 	}
 	result, err := alias.CheckTarget(target, cmdCtx.workspaceRoot)
 	if err != nil {

--- a/frontend/cli-go/internal/app/alias_create.go
+++ b/frontend/cli-go/internal/app/alias_create.go
@@ -12,7 +12,7 @@ import (
 func runAliasCreate(stdout io.Writer, cmdCtx commandContext, cmd aliasCommand) error {
 	class, kind, err := parseAliasCreateWrappedCommand(cmd.Wrapped)
 	if err != nil {
-		return ExitErrorf(2, err.Error())
+		return ExitErrorf(2, "%s", err.Error())
 	}
 
 	result, err := alias.Create(alias.CreateOptions{
@@ -24,7 +24,7 @@ func runAliasCreate(stdout io.Writer, cmdCtx commandContext, cmd aliasCommand) e
 		Args:          cmd.Args,
 	})
 	if err != nil {
-		return ExitErrorf(2, err.Error())
+		return ExitErrorf(2, "%s", err.Error())
 	}
 
 	if cmdCtx.output == "json" {

--- a/frontend/cli-go/internal/app/discover.go
+++ b/frontend/cli-go/internal/app/discover.go
@@ -45,7 +45,7 @@ func runDiscover(stdout io.Writer, stderr io.Writer, cmdCtx commandContext, args
 	}
 	selected, err = discover.NormalizeSelectedAnalyzers(selected)
 	if err != nil {
-		return ExitErrorf(2, err.Error())
+		return ExitErrorf(2, "%s", err.Error())
 	}
 	if showHelp {
 		cli.PrintDiscoverUsage(stdout)

--- a/frontend/cli-go/internal/app/ls.go
+++ b/frontend/cli-go/internal/app/ls.go
@@ -150,11 +150,11 @@ func runLs(w io.Writer, runOpts cli.LsOptions, args []string, output string) err
 	if err != nil {
 		var prefixErr *cli.IDPrefixError
 		if errors.As(err, &prefixErr) {
-			return ExitErrorf(2, prefixErr.Error())
+			return ExitErrorf(2, "%s", prefixErr.Error())
 		}
 		var ambiguousErr *cli.AmbiguousPrefixError
 		if errors.As(err, &ambiguousErr) {
-			return ExitErrorf(2, ambiguousErr.Error())
+			return ExitErrorf(2, "%s", ambiguousErr.Error())
 		}
 		return err
 	}

--- a/frontend/cli-go/internal/app/prepare.go
+++ b/frontend/cli-go/internal/app/prepare.go
@@ -647,7 +647,7 @@ func wrapInputsetError(err error) error {
 	}
 	var userErr *inputset.UserError
 	if errors.As(err, &userErr) {
-		return ExitErrorf(2, userErr.Message)
+		return ExitErrorf(2, "%s", userErr.Message)
 	}
 	return err
 }

--- a/frontend/cli-go/internal/app/ref_prepare.go
+++ b/frontend/cli-go/internal/app/ref_prepare.go
@@ -242,7 +242,7 @@ func joinCleanup(funcs ...func() error) func() error {
 			}
 		}
 		if len(errs) > 0 {
-			return ExitErrorf(1, strings.Join(errs, "; "))
+			return ExitErrorf(1, "%s", strings.Join(errs, "; "))
 		}
 		return nil
 	}

--- a/frontend/cli-go/internal/app/rm.go
+++ b/frontend/cli-go/internal/app/rm.go
@@ -106,15 +106,15 @@ func runRm(w io.Writer, runOpts cli.RmOptions, args []string, output string) err
 	if err != nil {
 		var prefixErr *cli.IDPrefixError
 		if errors.As(err, &prefixErr) {
-			return ExitErrorf(2, prefixErr.Error())
+			return ExitErrorf(2, "%s", prefixErr.Error())
 		}
 		var ambiguousErr *cli.AmbiguousPrefixError
 		if errors.As(err, &ambiguousErr) {
-			return ExitErrorf(2, ambiguousErr.Error())
+			return ExitErrorf(2, "%s", ambiguousErr.Error())
 		}
 		var resourceErr *cli.AmbiguousResourceError
 		if errors.As(err, &resourceErr) {
-			return ExitErrorf(2, resourceErr.Error())
+			return ExitErrorf(2, "%s", resourceErr.Error())
 		}
 		return ExitErrorf(3, "Internal error: %v", err)
 	}

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.22
+go 1.25
 
 use (
 	./backend/local-engine-go


### PR DESCRIPTION
## Summary

- Bump Go directives from 1.22 to 1.25 in `go.work`, CLI, and local engine modules.
- Update the CLI project spec to document Go 1.25+ as the supported toolchain.
- Fix dynamic error strings passed to `fmt.Errorf` / `ExitErrorf` by using explicit `%s` formatting.
- Update the flights example query to connect to the `demo` database and use the `bookings` schema.

## Validation

- `go vet ./...` in `frontend/cli-go`
- `go vet ./...` in `backend/local-engine-go`
- `go test ./... -count=1 -timeout=10m` in `frontend/cli-go`
- `go test ./... -count=1 -timeout=10m` in `backend/local-engine-go`

## Notes

- `.github/workflows/*.yml` may appear modified locally due to line-ending/index noise, but they have no content diff.
- The flights SQL change was reviewed against the PostgresPro demo schema; no live database smoke run was performed.