### PR TITLE
Preserve absolute workspace context during remote source sync

### DIFF
--- a/docs/adr/2026-07-20-portable-remote-source-path-binding.md
+++ b/docs/adr/2026-07-20-portable-remote-source-path-binding.md
@@ -1,0 +1,59 @@
+# 2026-07-20 Absolute Client Path Binding for Remote Sources
+
+- Conversation timestamp: 2026-07-20T11:52:53.0950999+07:00
+- GitHub user id involved in the decision: @evilguest (41718235)
+- Agent name/version involved in the decision: Codex / GPT-5
+- Status: Accepted
+
+## Question Discussed
+
+How should file-bearing prepare and cache-explain arguments identify local
+workspace files when a client and a remote Taidon deployment do not share a
+filesystem or operating-system path syntax?
+
+## Alternatives Considered
+
+1. Preserve absolute client host paths in `psql_args`, `liquibase_args`, and
+   `work_dir`, and attempt to open them directly in the remote runner.
+2. Convert every file-bearing request to inline stdin or an eagerly uploaded
+   workspace archive, bypassing the accepted manifest negotiation loop.
+3. Preserve absolute client paths as logical invocation coordinates, add the
+   client workspace root and effective working directory to the source
+   manifest context, and project the admitted request to runner-local paths
+   only after authoritative source resolution.
+
+## Chosen Solution Or Decision Made
+
+Choose alternative 3.
+
+The CLI continues to bind file-bearing arguments to absolute native client
+paths before it sends either local or remote requests. For remote source sync,
+`source_manifest.workspace_ref` also carries the absolute logical workspace
+root and effective command working directory. Those values use the same client
+path flavor as the request arguments and are coordinates for source resolution;
+they are never server filesystem locations.
+
+Manifest keys and `source_inputs_missing` paths remain workspace-relative and
+slash-separated. During admission, the authoritative resolver rebases absolute
+client paths against the supplied logical root, preserves the distinct `psql`
+`\i` and `\ir` bases, and produces a private workspace-relative execution
+projection. Only that projection is materialized as runner-local absolute paths.
+
+## Brief Rationale
+
+Absolute paths preserve the host-side binding selected for raw arguments,
+aliases, refs, `psql` includes, and Liquibase search paths. Rewriting them in
+the CLI would discard information needed to diagnose the exact missing import.
+At the same time, a Windows path cannot be opened by a Linux runner. An explicit
+logical root/work-dir binding preserves the accepted client contract while
+letting admission translate it deterministically into the portable manifest
+namespace and then into the runner filesystem.
+
+## Contradiction Check
+
+This decision refines, but does not obsolete,
+`2026-07-06-remote-source-input-sync-cli.md`,
+`2026-03-22-shared-inputset-layer.md`, or
+`2026-03-23-psql-include-base-semantics.md`. It preserves the existing absolute
+prepare-path contract and makes the previously implicit client-to-virtual
+workspace binding explicit.

--- a/docs/adr/2026-07-20-source-transfer-timeout.md
+++ b/docs/adr/2026-07-20-source-transfer-timeout.md
@@ -1,0 +1,41 @@
+# 2026-07-20 Dedicated Source Transfer Timeout
+
+- Conversation timestamp: 2026-07-20T20:22:03.0377476+07:00
+- GitHub user id involved in the decision: @evilguest (41718235)
+- Agent name/version involved in the decision: Codex / GPT-5
+- Status: Accepted
+
+## Question Discussed
+
+How should the CLI time out remote source blob uploads that can be much larger
+than ordinary control-plane requests?
+
+## Alternatives Considered
+
+1. Keep using the common 30-second HTTP client timeout.
+2. Increase the timeout for every CLI HTTP request.
+3. Add a new user-facing CLI flag or profile setting for upload timeout.
+4. Keep the configured control timeout and use a dedicated 15-minute deadline
+   for source blob transfer operations.
+
+## Chosen Solution Or Decision Made
+
+Choose alternative 4. Source blob uploads use a separate authenticated HTTP
+transfer client with a 15-minute default deadline. Prepare create, status, and
+other control requests retain their existing timeout semantics. No CLI syntax
+or configuration key is added.
+
+## Brief Rationale
+
+The maintained `flights-multi-step` example contains a 106,128,119-byte source
+file. A 30-second whole-request deadline is too short on ordinary uplinks, while
+raising every request timeout would hide control-plane failures. A separate
+deadline matches the distinct streaming workload without changing user-facing
+command syntax.
+
+## Contradiction Check
+
+This decision refines but does not obsolete
+`2026-07-06-remote-source-input-sync-cli.md` and
+`2026-07-20-portable-remote-source-path-binding.md`.
+

--- a/docs/api-guides/sqlrs-engine.md
+++ b/docs/api-guides/sqlrs-engine.md
@@ -452,7 +452,9 @@ const inputBody = '{
   "stdin": "string",
   "source_manifest": {
     "workspace_ref": {
-      "root_id": "string"
+      "root_id": "string",
+      "root_path": "string",
+      "work_dir": "string"
     },
     "files": {
       "property1": "string",
@@ -629,7 +631,9 @@ a job, instance, or mutate cache state.
   "stdin": "string",
   "source_manifest": {
     "workspace_ref": {
-      "root_id": "string"
+      "root_id": "string",
+      "root_path": "string",
+      "work_dir": "string"
     },
     "files": {
       "property1": "string",
@@ -894,7 +898,7 @@ string
 |400|[Bad Request](https://tools.ietf.org/html/rfc7231#section-6.5.1)|Invalid digest or upload request.|[ErrorResponse](#schemaerrorresponse)|
 |401|[Unauthorized](https://tools.ietf.org/html/rfc7235#section-3.1)|Unauthorized|None|
 |409|[Conflict](https://tools.ietf.org/html/rfc7231#section-6.5.8)|Uploaded content does not match the requested digest.|[ErrorResponse](#schemaerrorresponse)|
-|413|[Payload Too Large](https://tools.ietf.org/html/rfc7231#section-6.5.11)|Source blob exceeds the configured upload limit.|[ErrorResponse](#schemaerrorresponse)|
+|413|[Payload Too Large](https://tools.ietf.org/html/rfc7231#section-6.5.11)|Source blob exceeds the configured upload limit (`source_blob_too_large`).|[ErrorResponse](#schemaerrorresponse)|
 |500|[Internal Server Error](https://tools.ietf.org/html/rfc7231#section-6.6.1)|Internal error|[ErrorResponse](#schemaerrorresponse)|
 
 <aside class="warning">
@@ -1131,7 +1135,9 @@ const inputBody = '{
   "stdin": "string",
   "source_manifest": {
     "workspace_ref": {
-      "root_id": "string"
+      "root_id": "string",
+      "root_path": "string",
+      "work_dir": "string"
     },
     "files": {
       "property1": "string",
@@ -1311,7 +1317,9 @@ an instance; the plan tasks are returned in the job status.
   "stdin": "string",
   "source_manifest": {
     "workspace_ref": {
-      "root_id": "string"
+      "root_id": "string",
+      "root_path": "string",
+      "work_dir": "string"
     },
     "files": {
       "property1": "string",
@@ -6836,18 +6844,22 @@ workspace root.
 
 ```json
 {
-  "root_id": "string"
+  "root_id": "string",
+  "root_path": "string",
+  "work_dir": "string"
 }
 
 ```
 
-Optional client-local workspace identity. It is not a server filesystem path.
+Client path context used to bind absolute arguments to the virtual workspace.
 
 ### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
 |root_id|string|false|none|Client-local workspace root identifier for diagnostics and retries.|
+|root_path|string|true|none|Absolute logical path of the client workspace root, in the same OS<br>path flavor as file-bearing request arguments. It is a resolution<br>coordinate and is never opened as a server filesystem path.|
+|work_dir|string|true|none|Absolute logical effective command working directory within<br>`root_path`, in the same OS path flavor. Plain `psql` includes are<br>resolved from this directory.|
 
 <h2 id="tocS_SourceDirectoryEntry">SourceDirectoryEntry</h2>
 <!-- backwards compatibility -->
@@ -6919,7 +6931,9 @@ Complete listing for the directory at the map key.
 ```json
 {
   "workspace_ref": {
-    "root_id": "string"
+    "root_id": "string",
+    "root_path": "string",
+    "work_dir": "string"
   },
   "files": {
     "property1": "string",
@@ -6952,13 +6966,16 @@ Complete listing for the directory at the map key.
 Optional remote-source manifest attached to file-bearing prepare and
 cache-explain requests. The server uses this manifest with its scoped
 content cache to build a virtual workspace for authoritative
-format-specific input resolution.
+format-specific input resolution. File-bearing request arguments retain
+absolute client paths; `workspace_ref` binds those logical coordinates
+to workspace-relative manifest keys. An empty manifest is a valid
+first-round handshake and may produce `source_inputs_missing`.
 
 ### Properties
 
 |Name|Type|Required|Restrictions|Description|
 |---|---|---|---|---|
-|workspace_ref|[SourceWorkspaceRef](#schemasourceworkspaceref)|false|none|Optional client-local workspace identity. It is not a server filesystem path.|
+|workspace_ref|[SourceWorkspaceRef](#schemasourceworkspaceref)|true|none|Client path context used to bind absolute arguments to the virtual workspace.|
 |files|object|false|none|Map from workspace-relative source file path to verified client-side content hash.|
 |» **additionalProperties**|[SourceContentHash](#schemasourcecontenthash)|false|none|SHA-256 content hash with the `sha256:` prefix.|
 |directories|object|false|none|Map from workspace-relative directory path to complete directory listing.|
@@ -7074,7 +7091,9 @@ directory listings, and retry the original request.
   "stdin": "string",
   "source_manifest": {
     "workspace_ref": {
-      "root_id": "string"
+      "root_id": "string",
+      "root_path": "string",
+      "work_dir": "string"
     },
     "files": {
       "property1": "string",
@@ -7136,7 +7155,9 @@ xor
   "stdin": "string",
   "source_manifest": {
     "workspace_ref": {
-      "root_id": "string"
+      "root_id": "string",
+      "root_path": "string",
+      "work_dir": "string"
     },
     "files": {
       "property1": "string",
@@ -7173,9 +7194,9 @@ xor
 |---|---|---|---|---|
 |prepare_kind|string|true|none|Prepare adapter kind.|
 |image_id|string|true|none|Base Docker image id to use.|
-|psql_args|[string]|true|none|Arguments passed to `psql` (excluding connection flags). Argument<br>ordering is preserved. File paths must already be normalized for<br>the bound local execution context.|
+|psql_args|[string]|true|none|Arguments passed to `psql` (excluding connection flags). Argument<br>ordering is preserved. File paths must already be absolute and<br>normalized for the bound client execution context. With<br>`source_manifest`, they are logical client coordinates and are not<br>opened on the server filesystem.|
 |stdin|string|false|none|SQL content to use for stdin when `psql_args` includes `-f -`.|
-|source_manifest|[SourceManifest](#schemasourcemanifest)|false|none|Optional remote-source manifest attached to file-bearing prepare and<br>cache-explain requests. The server uses this manifest with its scoped<br>content cache to build a virtual workspace for authoritative<br>format-specific input resolution.|
+|source_manifest|[SourceManifest](#schemasourcemanifest)|false|none|Optional remote-source manifest attached to file-bearing prepare and<br>cache-explain requests. The server uses this manifest with its scoped<br>content cache to build a virtual workspace for authoritative<br>format-specific input resolution. File-bearing request arguments retain<br>absolute client paths; `workspace_ref` binds those logical coordinates<br>to workspace-relative manifest keys. An empty manifest is a valid<br>first-round handshake and may produce `source_inputs_missing`.|
 
 #### Enumerated Values
 
@@ -7206,7 +7227,9 @@ xor
   "work_dir": "string",
   "source_manifest": {
     "workspace_ref": {
-      "root_id": "string"
+      "root_id": "string",
+      "root_path": "string",
+      "work_dir": "string"
     },
     "files": {
       "property1": "string",
@@ -7243,13 +7266,13 @@ xor
 |---|---|---|---|---|
 |prepare_kind|string|true|none|Prepare adapter kind.|
 |image_id|string|true|none|Base Docker image id to use.|
-|liquibase_args|[string]|true|none|Arguments passed to Liquibase. Argument ordering is preserved and<br>path-bearing arguments must already reflect the bound local<br>execution context.|
+|liquibase_args|[string]|true|none|Arguments passed to Liquibase. Argument ordering is preserved and<br>path-bearing arguments must already reflect the absolute bound<br>client execution context. With `source_manifest`, they are logical<br>client coordinates and are not opened on the server filesystem.|
 |liquibase_exec|string|false|none|Optional Liquibase executable override selected by the CLI.|
 |liquibase_exec_mode|string|false|none|Optional Liquibase executable mode selected by the CLI.|
 |liquibase_env|object|false|none|Optional environment variables passed through to Liquibase.|
 |» **additionalProperties**|string|false|none|none|
-|work_dir|string|false|none|Working directory for the Liquibase invocation.|
-|source_manifest|[SourceManifest](#schemasourcemanifest)|false|none|Optional remote-source manifest attached to file-bearing prepare and<br>cache-explain requests. The server uses this manifest with its scoped<br>content cache to build a virtual workspace for authoritative<br>format-specific input resolution.|
+|work_dir|string|false|none|Absolute bound client working directory for the Liquibase invocation.|
+|source_manifest|[SourceManifest](#schemasourcemanifest)|false|none|Optional remote-source manifest attached to file-bearing prepare and<br>cache-explain requests. The server uses this manifest with its scoped<br>content cache to build a virtual workspace for authoritative<br>format-specific input resolution. File-bearing request arguments retain<br>absolute client paths; `workspace_ref` binds those logical coordinates<br>to workspace-relative manifest keys. An empty manifest is a valid<br>first-round handshake and may produce `source_inputs_missing`.|
 
 #### Enumerated Values
 
@@ -7338,7 +7361,9 @@ or
   "stdin": "string",
   "source_manifest": {
     "workspace_ref": {
-      "root_id": "string"
+      "root_id": "string",
+      "root_path": "string",
+      "work_dir": "string"
     },
     "files": {
       "property1": "string",
@@ -7401,7 +7426,9 @@ xor
   "stdin": "string",
   "source_manifest": {
     "workspace_ref": {
-      "root_id": "string"
+      "root_id": "string",
+      "root_path": "string",
+      "work_dir": "string"
     },
     "files": {
       "property1": "string",
@@ -7439,9 +7466,9 @@ xor
 |---|---|---|---|---|
 |prepare_kind|string|true|none|Prepare adapter kind.|
 |image_id|string|true|none|Base Docker image id to use.|
-|psql_args|[string]|true|none|Arguments passed to `psql` (excluding connection flags). Argument<br>ordering is preserved. File paths must be absolute.|
+|psql_args|[string]|true|none|Arguments passed to `psql` (excluding connection flags). Argument<br>ordering is preserved. File paths must be absolute. With<br>`source_manifest`, they are logical client coordinates and are not<br>opened on the server filesystem.|
 |stdin|string|false|none|SQL content to use for stdin when `psql_args` includes `-f -`.|
-|source_manifest|[SourceManifest](#schemasourcemanifest)|false|none|Optional remote-source manifest attached to file-bearing prepare and<br>cache-explain requests. The server uses this manifest with its scoped<br>content cache to build a virtual workspace for authoritative<br>format-specific input resolution.|
+|source_manifest|[SourceManifest](#schemasourcemanifest)|false|none|Optional remote-source manifest attached to file-bearing prepare and<br>cache-explain requests. The server uses this manifest with its scoped<br>content cache to build a virtual workspace for authoritative<br>format-specific input resolution. File-bearing request arguments retain<br>absolute client paths; `workspace_ref` binds those logical coordinates<br>to workspace-relative manifest keys. An empty manifest is a valid<br>first-round handshake and may produce `source_inputs_missing`.|
 |plan_only|boolean|false|none|When true, only the plan is computed and no instance is created.|
 
 #### Enumerated Values
@@ -7473,7 +7500,9 @@ xor
   "work_dir": "string",
   "source_manifest": {
     "workspace_ref": {
-      "root_id": "string"
+      "root_id": "string",
+      "root_path": "string",
+      "work_dir": "string"
     },
     "files": {
       "property1": "string",
@@ -7511,13 +7540,13 @@ xor
 |---|---|---|---|---|
 |prepare_kind|string|true|none|Prepare adapter kind.|
 |image_id|string|true|none|Base Docker image id to use.|
-|liquibase_args|[string]|true|none|Arguments passed to Liquibase. Argument ordering is preserved and<br>path-bearing arguments must already be normalized for the bound<br>local execution context.|
+|liquibase_args|[string]|true|none|Arguments passed to Liquibase. Argument ordering is preserved and<br>path-bearing arguments must already be normalized for the absolute<br>bound client execution context. With `source_manifest`, they are<br>logical client coordinates and are not opened on the server<br>filesystem.|
 |liquibase_exec|string|false|none|Optional Liquibase executable override selected by the CLI.|
 |liquibase_exec_mode|string|false|none|Optional Liquibase executable mode selected by the CLI.|
 |liquibase_env|object|false|none|Optional environment variables passed through to Liquibase.|
 |» **additionalProperties**|string|false|none|none|
-|work_dir|string|false|none|Working directory for the Liquibase invocation.|
-|source_manifest|[SourceManifest](#schemasourcemanifest)|false|none|Optional remote-source manifest attached to file-bearing prepare and<br>cache-explain requests. The server uses this manifest with its scoped<br>content cache to build a virtual workspace for authoritative<br>format-specific input resolution.|
+|work_dir|string|false|none|Absolute bound client working directory for the Liquibase invocation.|
+|source_manifest|[SourceManifest](#schemasourcemanifest)|false|none|Optional remote-source manifest attached to file-bearing prepare and<br>cache-explain requests. The server uses this manifest with its scoped<br>content cache to build a virtual workspace for authoritative<br>format-specific input resolution. File-bearing request arguments retain<br>absolute client paths; `workspace_ref` binds those logical coordinates<br>to workspace-relative manifest keys. An empty manifest is a valid<br>first-round handshake and may produce `source_inputs_missing`.|
 |plan_only|boolean|false|none|When true, only the plan is computed and no instance is created.|
 
 #### Enumerated Values

--- a/docs/api-guides/sqlrs-engine.openapi.yaml
+++ b/docs/api-guides/sqlrs-engine.openapi.yaml
@@ -149,7 +149,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/ErrorResponse"
         "413":
-          description: Source blob exceeds the configured upload limit.
+          description: Source blob exceeds the configured upload limit (`source_blob_too_large`).
           content:
             application/json:
               schema:
@@ -1521,11 +1521,28 @@ components:
     SourceWorkspaceRef:
       type: object
       additionalProperties: false
+      required:
+        - root_path
+        - work_dir
       properties:
         root_id:
           type: string
           description: Client-local workspace root identifier for diagnostics and retries.
-      description: Optional client-local workspace identity. It is not a server filesystem path.
+        root_path:
+          type: string
+          minLength: 1
+          description: |
+            Absolute logical path of the client workspace root, in the same OS
+            path flavor as file-bearing request arguments. It is a resolution
+            coordinate and is never opened as a server filesystem path.
+        work_dir:
+          type: string
+          minLength: 1
+          description: |
+            Absolute logical effective command working directory within
+            `root_path`, in the same OS path flavor. Plain `psql` includes are
+            resolved from this directory.
+      description: Client path context used to bind absolute arguments to the virtual workspace.
     SourceDirectoryEntry:
       type: object
       additionalProperties: false
@@ -1559,6 +1576,8 @@ components:
     SourceManifest:
       type: object
       additionalProperties: false
+      required:
+        - workspace_ref
       properties:
         workspace_ref:
           $ref: "#/components/schemas/SourceWorkspaceRef"
@@ -1576,7 +1595,10 @@ components:
         Optional remote-source manifest attached to file-bearing prepare and
         cache-explain requests. The server uses this manifest with its scoped
         content cache to build a virtual workspace for authoritative
-        format-specific input resolution.
+        format-specific input resolution. File-bearing request arguments retain
+        absolute client paths; `workspace_ref` binds those logical coordinates
+        to workspace-relative manifest keys. An empty manifest is a valid
+        first-round handshake and may produce `source_inputs_missing`.
     SourceMissingManifestEntry:
       type: object
       additionalProperties: false
@@ -1660,8 +1682,10 @@ components:
           type: array
           description: |
             Arguments passed to `psql` (excluding connection flags). Argument
-            ordering is preserved. File paths must already be normalized for
-            the bound local execution context.
+            ordering is preserved. File paths must already be absolute and
+            normalized for the bound client execution context. With
+            `source_manifest`, they are logical client coordinates and are not
+            opened on the server filesystem.
           items:
             type: string
         stdin:
@@ -1688,8 +1712,9 @@ components:
           type: array
           description: |
             Arguments passed to Liquibase. Argument ordering is preserved and
-            path-bearing arguments must already reflect the bound local
-            execution context.
+            path-bearing arguments must already reflect the absolute bound
+            client execution context. With `source_manifest`, they are logical
+            client coordinates and are not opened on the server filesystem.
           items:
             type: string
         liquibase_exec:
@@ -1705,7 +1730,7 @@ components:
           description: Optional environment variables passed through to Liquibase.
         work_dir:
           type: string
-          description: Working directory for the Liquibase invocation.
+          description: Absolute bound client working directory for the Liquibase invocation.
         source_manifest:
           $ref: "#/components/schemas/SourceManifest"
     CacheExplainPrepareResponse:
@@ -1768,7 +1793,9 @@ components:
           type: array
           description: |
             Arguments passed to `psql` (excluding connection flags). Argument
-            ordering is preserved. File paths must be absolute.
+            ordering is preserved. File paths must be absolute. With
+            `source_manifest`, they are logical client coordinates and are not
+            opened on the server filesystem.
           items:
             type: string
         stdin:
@@ -1798,8 +1825,10 @@ components:
           type: array
           description: |
             Arguments passed to Liquibase. Argument ordering is preserved and
-            path-bearing arguments must already be normalized for the bound
-            local execution context.
+            path-bearing arguments must already be normalized for the absolute
+            bound client execution context. With `source_manifest`, they are
+            logical client coordinates and are not opened on the server
+            filesystem.
           items:
             type: string
         liquibase_exec:
@@ -1815,7 +1844,7 @@ components:
           description: Optional environment variables passed through to Liquibase.
         work_dir:
           type: string
-          description: Working directory for the Liquibase invocation.
+          description: Absolute bound client working directory for the Liquibase invocation.
         source_manifest:
           $ref: "#/components/schemas/SourceManifest"
         plan_only:

--- a/docs/architecture/cli-component-structure.RU.md
+++ b/docs/architecture/cli-component-structure.RU.md
@@ -54,8 +54,8 @@
     `remote-source-input-sync-flow.RU.md`.
   - Владеет расширением `source_manifest`, bounded retry для
     `source_inputs_missing`, безопасным workspace-relative path resolution,
-    хэшированием и upload-ом запрошенных source blob-ов, а также progress
-    reporting в stderr текущей stage.
+    хэшированием и upload-ом запрошенных source blob-ов, logical context
+    workspace root/work dir и progress reporting в stderr текущей stage.
 - `internal/inputset`
   - Общий CLI-side источник истины для file-bearing семантики команд.
   - Владеет staged абстракциями parse/bind/collect/project и общими типами.
@@ -146,6 +146,10 @@
   - Payload remote source-sync manifest и recoverable missing-input response.
 - `remotesource.Options`, `remotesource.Uploader`
   - Опции выполнения remote source-sync и boundary для upload source blob-ов.
+- `remotesource.ClientWorkspaceContext`
+  - Передаёт absolute logical client workspace root и effective working
+    directory, используемые для отображения bound paths `psql` и Liquibase в
+    manifest keys.
 - `client.RunRequest`, `client.RunEvent`
   - Payload run API и стрим событий (`stdout`, `stderr`, `exit`, `error`,
     `log`).
@@ -174,6 +178,8 @@
 - Remote source manifests, retry state для missing-input и тела uploaded source
   blob-ов эфемерны в рамках одного invocation. CLI может отправлять source
   blob-ы только в аутентифицированный remote API и не сохраняет их в CLI config.
+- HTTP client разделяет deadlines control requests и source transfer; default
+  source-transfer deadline равен 15 минутам.
 - Состояние discovery локального engine (`engine.json`, daemon lock/process
   metadata) ведется через `internal/daemon`.
 - Rendered alias-create commands эфемерны и существуют только в CLI output.

--- a/docs/architecture/cli-component-structure.md
+++ b/docs/architecture/cli-component-structure.md
@@ -53,7 +53,8 @@ addition of a shared `inputset` layer for file-bearing command semantics.
     `remote-source-input-sync-flow.md`.
   - Owns `source_manifest` expansion, bounded `source_inputs_missing` retry,
     safe workspace-relative path resolution, requested source blob hashing and
-    upload, and progress reporting to the stage stderr writer.
+    upload, logical workspace-root/work-dir context, and progress reporting to
+    the stage stderr writer.
 - `internal/inputset`
   - Shared CLI-side source of truth for file-bearing command semantics.
   - Owns staged parse/bind/collect/project abstractions and common helper types.
@@ -143,6 +144,9 @@ addition of a shared `inputset` layer for file-bearing command semantics.
   - Remote source-sync manifest payload and recoverable missing-input response.
 - `remotesource.Options`, `remotesource.Uploader`
   - Remote source-sync execution options and source blob upload boundary.
+- `remotesource.ClientWorkspaceContext`
+  - Carries the absolute logical client workspace root and effective working
+    directory used to map bound `psql` and Liquibase paths into manifest keys.
 - `client.RunRequest`, `client.RunEvent`
   - Run API payload and streamed events (`stdout`, `stderr`, `exit`, `error`,
     `log`).
@@ -171,6 +175,8 @@ addition of a shared `inputset` layer for file-bearing command semantics.
 - Remote source manifests, missing-input retry state, and uploaded source blob
   bodies are ephemeral per invocation. The CLI may send source blobs only to the
   authenticated remote API; it does not persist them in CLI config.
+- The HTTP client keeps control-request and source-transfer deadlines separate;
+  the default source-transfer deadline is 15 minutes.
 - Engine discovery state (`engine.json`, daemon lock/process metadata) is
   managed via `internal/daemon`.
 - Rendered alias-create commands are ephemeral and exist only in CLI output.

--- a/docs/architecture/remote-source-input-sync-flow.RU.md
+++ b/docs/architecture/remote-source-input-sync-flow.RU.md
@@ -24,6 +24,12 @@ remote backend.
   `PUT /v1/source-blobs/sha256/{digest}`.
 - Recoverable missing-input negotiation использует
   `409 source_inputs_missing`.
+- CLI сохраняет absolute native path bindings в аргументах remote request и
+  прикладывает logical client workspace root и effective working directory.
+  Admission отображает эти координаты в workspace-relative manifest paths;
+  remote runner никогда не открывает client paths напрямую.
+- Source blob uploads используют отдельный 15-minute transfer timeout; prepare
+  control requests сохраняют configured control timeout.
 
 ## 2. Remote Prepare
 
@@ -33,6 +39,7 @@ sequenceDiagram
     participant Client as "internal/client"
     participant Gateway as "remote gateway"
 
+    CLI->>CLI: "attach logical workspace root and working directory"
     CLI->>Client: "POST /v1/prepare-jobs + source_manifest"
     Client->>Gateway: "prepare request"
     alt "source inputs missing"
@@ -94,3 +101,6 @@ terminal client errors:
 - blob upload отклонен;
 - retry loop исчерпал лимит.
 
+Upload timeout возвращается как source-transfer failure и не создаёт prepare
+job. Absolute client paths являются logical resolution coordinates, а не
+fallback server filesystem location.

--- a/docs/architecture/remote-source-input-sync-flow.md
+++ b/docs/architecture/remote-source-input-sync-flow.md
@@ -22,6 +22,12 @@ Related documents:
 - Source blob uploads are content-addressed by SHA-256 and sent to
   `PUT /v1/source-blobs/sha256/{digest}`.
 - Recoverable missing-input negotiation uses `409 source_inputs_missing`.
+- The CLI preserves absolute native path bindings in remote request arguments
+  and attaches the logical client workspace root and effective working
+  directory. Admission maps those coordinates to workspace-relative manifest
+  paths; a remote runner never opens the client paths directly.
+- Source blob uploads use a dedicated 15-minute transfer timeout; prepare
+  control requests retain the configured control timeout.
 
 ## 2. Remote Prepare
 
@@ -31,6 +37,7 @@ sequenceDiagram
     participant Client as "internal/client"
     participant Gateway as "remote gateway"
 
+    CLI->>CLI: "attach logical workspace root and working directory"
     CLI->>Client: "POST /v1/prepare-jobs + source_manifest"
     Client->>Gateway: "prepare request"
     alt "source inputs missing"
@@ -93,3 +100,6 @@ terminal client errors:
 - rejected blob uploads;
 - retry loop exhaustion.
 
+An upload timeout is reported as a source-transfer failure and does not create
+a prepare job. Absolute client paths are logical resolution coordinates, never
+a fallback server filesystem location.

--- a/docs/roadmap.RU.md
+++ b/docs/roadmap.RU.md
@@ -196,7 +196,11 @@ gantt
   загружает запрошенные blob-ы через `/v1/source-blobs/sha256/{digest}`,
   пишет progress синхронизации в stderr, учитывает per-profile `sourceSync`
   policy и использует выбранный ref filesystem для ref-backed prepare stages.
-  Поведение local profile не меняется.
+  Поведение local profile не меняется. Production handshake теперь также
+  передает абсолютные client coordinates `root_path`/`work_dir`, сохраняет
+  абсолютные public prepare arguments, использует отдельный 15-минутный
+  source-transfer timeout и работает с gateway-owned admission projection без
+  изменения CLI syntax.
 - **В работе (базовый CI-template слой)**: GitHub Actions release/e2e пайплайны
   уже активны; более широкие team-шаблоны (например, GitLab и on-prem варианты)
   ещё впереди.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -194,7 +194,10 @@ gantt
   uploads requested blobs through `/v1/source-blobs/sha256/{digest}`, reports
   sync progress to stderr, honors per-profile `sourceSync` policy, and uses the
   selected ref filesystem for ref-backed prepare stages. Local profile behavior
-  is unchanged.
+  is unchanged. The production handshake now also sends absolute client
+  `root_path`/`work_dir` coordinates, retains absolute public prepare arguments,
+  uses a dedicated 15-minute source-transfer timeout, and interoperates with
+  the gateway-owned admission projection without changing the CLI syntax.
 - **In progress (CI templates baseline)**: GitHub Actions-based release/e2e flows
   are active; broader team templates (e.g., GitLab and on-prem deployment variants)
   are still pending.

--- a/docs/user-guides/remote-source-input-sync.md
+++ b/docs/user-guides/remote-source-input-sync.md
@@ -28,6 +28,13 @@ input responses, uploads only server-requested content blobs, and retries the
 original request. Successful command stdout stays unchanged; source-sync
 progress is written to stderr.
 
+The CLI binds path-bearing arguments to absolute native paths before sending a
+request. Remote source sync preserves those paths as logical client coordinates;
+the server does not try to open them on its own filesystem. The attached
+workspace context identifies the absolute client workspace root and effective
+working directory so admission can map arguments and imports into the
+workspace-relative manifest namespace.
+
 ## Profile Configuration
 
 Remote source sync is enabled by default for remote profiles.
@@ -64,6 +71,8 @@ Conceptual shape:
 source_manifest:
   workspace_ref:
     root_id: default
+    root_path: 'C:\work\project'
+    work_dir: 'C:\work\project\db'
   files:
     db/changelog/master.xml: sha256:...
     db/changelog/001.sql: sha256:...
@@ -76,9 +85,17 @@ source_manifest:
           kind: directory
 ```
 
-The server remains authoritative for format-specific dependency traversal. The
-client can send a narrow seed manifest, then expand it only when the server asks
-for file hashes, directory listings, or content blobs.
+`root_path` and `work_dir` use the client's native absolute path syntax. They
+bind absolute request arguments to manifest keys and are not server filesystem
+paths. The server remains authoritative for format-specific dependency
+traversal. The client can send a narrow seed manifest, then expand it only when
+the server asks for file hashes, directory listings, or content blobs.
+
+The first request may contain an empty manifest. The server rebases absolute
+path-bearing arguments against the logical client workspace context, derives
+the initial required entries, and returns workspace-relative
+`source_inputs_missing` paths. It must not create a prepare job until source
+admission has succeeded.
 
 ## Missing Input Loop
 
@@ -119,6 +136,16 @@ The command fails when a requested local path is unavailable, a local hash does
 not match the server-requested hash, a blob upload is rejected, the retry limit
 is reached, or the server returns a non-recoverable error.
 
+With verbose output enabled, each recoverable round reports the number of
+requested manifest entries and blobs, followed by the number uploaded. No
+source-sync progress lines means that the server did not return a
+`source_inputs_missing` response.
+
+Each deployment defines a maximum size for one source blob. A file within that
+published limit is uploaded as one content-addressed blob; a larger file fails
+with `413 source_blob_too_large`. Supported deployments must configure the limit
+high enough for the maintained file-backed examples.
+
 ## Ref Mode
 
 For `--ref-mode worktree`, source sync reads from the projected detached
@@ -126,4 +153,3 @@ worktree.
 
 For `--ref-mode blob`, source sync reads from the Git object-backed filesystem.
 It must not fall back to the caller's current worktree for source bytes.
-

--- a/frontend/cli-go/internal/app/source_sync_test.go
+++ b/frontend/cli-go/internal/app/source_sync_test.go
@@ -95,6 +95,7 @@ func TestExplainPrepareCacheWithSourceSyncRetriesAndUploads(t *testing.T) {
 func TestBuildRemoteSourceSyncOptionsModesAndRefContext(t *testing.T) {
 	root := t.TempDir()
 	refRoot := t.TempDir()
+	refBase := filepath.Join(refRoot, "nested")
 	refFS := sentinelSourceFS{}
 
 	got, err := buildRemoteSourceSyncOptions(io.Discard, cli.PrepareOptions{
@@ -107,6 +108,7 @@ func TestBuildRemoteSourceSyncOptionsModesAndRefContext(t *testing.T) {
 		invocationCwd: t.TempDir(),
 	}, &refctx.Context{
 		WorkspaceRoot: refRoot,
+		BaseDir:       refBase,
 		FileSystem:    refFS,
 	})
 	if err != nil {
@@ -114,6 +116,9 @@ func TestBuildRemoteSourceSyncOptionsModesAndRefContext(t *testing.T) {
 	}
 	if got == nil || !got.Enabled || got.WorkspaceRoot != refRoot || got.WorkspaceID != "remote" || got.MaxRounds != 3 {
 		t.Fatalf("unexpected source sync options: %+v", got)
+	}
+	if got.WorkDir != refBase {
+		t.Fatalf("source sync work dir = %q, want %q", got.WorkDir, refBase)
 	}
 	if got.FileSystem != refFS {
 		t.Fatalf("source sync should use ref filesystem, got %#v", got.FileSystem)
@@ -138,6 +143,28 @@ func TestBuildRemoteSourceSyncOptionsModesAndRefContext(t *testing.T) {
 	_, err = buildRemoteSourceSyncOptions(io.Discard, cli.PrepareOptions{Mode: "remote", SourceSyncMode: "manual"}, stageRunRequest{workspaceRoot: root}, nil)
 	if err == nil || !strings.Contains(err.Error(), "unsupported sourceSync.mode") {
 		t.Fatalf("expected unsupported sourceSync.mode error, got %v", err)
+	}
+}
+
+func TestBuildRemoteSourceSyncOptionsWorkspaceFallbacks(t *testing.T) {
+	t.Parallel()
+
+	repoRoot := t.TempDir()
+	fromRef, err := buildRemoteSourceSyncOptions(io.Discard, cli.PrepareOptions{Mode: "remote"}, stageRunRequest{}, &refctx.Context{RepoRoot: repoRoot})
+	if err != nil || fromRef.WorkspaceRoot != repoRoot || fromRef.WorkDir != repoRoot {
+		t.Fatalf("repo-root fallback = %+v,%v", fromRef, err)
+	}
+
+	cwd := t.TempDir()
+	fromCWD, err := buildRemoteSourceSyncOptions(io.Discard, cli.PrepareOptions{Mode: "remote"}, stageRunRequest{cwd: cwd}, nil)
+	if err != nil || fromCWD.WorkspaceRoot != cwd || fromCWD.WorkDir != cwd {
+		t.Fatalf("cwd fallback = %+v,%v", fromCWD, err)
+	}
+
+	invocation := t.TempDir()
+	fromInvocation, err := buildRemoteSourceSyncOptions(io.Discard, cli.PrepareOptions{Mode: "remote"}, stageRunRequest{invocationCwd: invocation}, nil)
+	if err != nil || fromInvocation.WorkspaceRoot != invocation || fromInvocation.WorkDir != invocation {
+		t.Fatalf("invocation fallback = %+v,%v", fromInvocation, err)
 	}
 }
 

--- a/frontend/cli-go/internal/app/stage_pipeline.go
+++ b/frontend/cli-go/internal/app/stage_pipeline.go
@@ -154,6 +154,7 @@ func buildRemoteSourceSyncOptions(stderr io.Writer, opts cli.PrepareOptions, req
 	}
 
 	root := strings.TrimSpace(req.workspaceRoot)
+	workDir := strings.TrimSpace(req.cwd)
 	var sourceFS inputset.FileSystem
 	if actualRef != nil {
 		root = strings.TrimSpace(actualRef.WorkspaceRoot)
@@ -161,6 +162,7 @@ func buildRemoteSourceSyncOptions(stderr io.Writer, opts cli.PrepareOptions, req
 			root = strings.TrimSpace(actualRef.RepoRoot)
 		}
 		sourceFS = actualRef.FileSystem
+		workDir = strings.TrimSpace(actualRef.BaseDir)
 	}
 	if root == "" {
 		root = strings.TrimSpace(req.cwd)
@@ -168,10 +170,14 @@ func buildRemoteSourceSyncOptions(stderr io.Writer, opts cli.PrepareOptions, req
 	if root == "" {
 		root = strings.TrimSpace(req.invocationCwd)
 	}
+	if workDir == "" {
+		workDir = root
+	}
 	return &remotesource.Options{
 		Enabled:       true,
 		MaxRounds:     opts.SourceSyncMaxRounds,
 		WorkspaceRoot: root,
+		WorkDir:       workDir,
 		WorkspaceID:   opts.ProfileName,
 		FileSystem:    sourceFS,
 		Progress:      stderr,

--- a/frontend/cli-go/internal/client/http_client.go
+++ b/frontend/cli-go/internal/client/http_client.go
@@ -14,16 +14,18 @@ import (
 )
 
 type Options struct {
-	Timeout   time.Duration
-	AuthToken string
-	UserAgent string
+	Timeout               time.Duration
+	SourceTransferTimeout time.Duration
+	AuthToken             string
+	UserAgent             string
 }
 
 type Client struct {
-	baseURL   string
-	http      *http.Client
-	authToken string
-	userAgent string
+	baseURL    string
+	http       *http.Client
+	sourceHTTP *http.Client
+	authToken  string
+	userAgent  string
 }
 
 func New(baseURL string, opts Options) *Client {
@@ -31,28 +33,36 @@ func New(baseURL string, opts Options) *Client {
 	if timeout == 0 {
 		timeout = 30 * time.Second
 	}
-	client := &http.Client{Timeout: timeout}
-	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if len(via) == 0 {
+	sourceTimeout := opts.SourceTransferTimeout
+	if sourceTimeout == 0 {
+		sourceTimeout = 15 * time.Minute
+	}
+	newHTTPClient := func(clientTimeout time.Duration) *http.Client {
+		client := &http.Client{Timeout: clientTimeout}
+		client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+			if len(via) == 0 {
+				return nil
+			}
+			prev := via[len(via)-1]
+			if auth := prev.Header.Get("Authorization"); auth != "" {
+				req.Header.Set("Authorization", auth)
+			}
+			if ua := prev.Header.Get("User-Agent"); ua != "" {
+				req.Header.Set("User-Agent", ua)
+			}
+			if len(via) >= 10 {
+				return errors.New("stopped after 10 redirects")
+			}
 			return nil
 		}
-		prev := via[len(via)-1]
-		if auth := prev.Header.Get("Authorization"); auth != "" {
-			req.Header.Set("Authorization", auth)
-		}
-		if ua := prev.Header.Get("User-Agent"); ua != "" {
-			req.Header.Set("User-Agent", ua)
-		}
-		if len(via) >= 10 {
-			return errors.New("stopped after 10 redirects")
-		}
-		return nil
+		return client
 	}
 	return &Client{
-		baseURL:   normalizeBaseURL(baseURL),
-		http:      client,
-		authToken: opts.AuthToken,
-		userAgent: opts.UserAgent,
+		baseURL:    normalizeBaseURL(baseURL),
+		http:       newHTTPClient(timeout),
+		sourceHTTP: newHTTPClient(sourceTimeout),
+		authToken:  opts.AuthToken,
+		userAgent:  opts.UserAgent,
 	}
 }
 
@@ -182,7 +192,7 @@ func (c *Client) CreatePrepareJob(ctx context.Context, req PrepareJobRequest) (P
 
 func (c *Client) PutSourceBlob(ctx context.Context, digest string, body io.Reader) error {
 	path := "/v1/source-blobs/sha256/" + url.PathEscape(strings.TrimSpace(digest))
-	resp, err := c.doRequestWithBody(ctx, http.MethodPut, path, true, body, "application/octet-stream")
+	resp, err := c.doSourceRequestWithBody(ctx, http.MethodPut, path, true, body, "application/octet-stream")
 	if err != nil {
 		return err
 	}
@@ -448,6 +458,18 @@ func (c *Client) doRequestWithBody(ctx context.Context, method, path string, use
 }
 
 func (c *Client) doRequestWithBodyHeaders(ctx context.Context, method, path string, useAuth bool, body io.Reader, contentType string, headers map[string]string) (*http.Response, error) {
+	return c.doRequestWithBodyHeadersUsing(c.http, ctx, method, path, useAuth, body, contentType, headers)
+}
+
+func (c *Client) doSourceRequestWithBody(ctx context.Context, method, path string, useAuth bool, body io.Reader, contentType string) (*http.Response, error) {
+	httpClient := c.sourceHTTP
+	if httpClient == nil {
+		httpClient = c.http
+	}
+	return c.doRequestWithBodyHeadersUsing(httpClient, ctx, method, path, useAuth, body, contentType, nil)
+}
+
+func (c *Client) doRequestWithBodyHeadersUsing(httpClient *http.Client, ctx context.Context, method, path string, useAuth bool, body io.Reader, contentType string, headers map[string]string) (*http.Response, error) {
 	url := c.baseURL + path
 	req, err := http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
@@ -468,7 +490,7 @@ func (c *Client) doRequestWithBodyHeaders(ctx context.Context, method, path stri
 		}
 		req.Header.Set(key, value)
 	}
-	return c.http.Do(req)
+	return httpClient.Do(req)
 }
 
 func normalizeBaseURL(raw string) string {

--- a/frontend/cli-go/internal/client/source_sync_test.go
+++ b/frontend/cli-go/internal/client/source_sync_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestCreatePrepareJobParsesSourceInputsMissing(t *testing.T) {
@@ -27,6 +28,28 @@ func TestCreatePrepareJobParsesSourceInputsMissing(t *testing.T) {
 	}
 	if missing.StatusCode != http.StatusConflict || len(missing.Response.MissingManifestEntries) != 1 || len(missing.Response.MissingBlobs) != 1 {
 		t.Fatalf("unexpected missing response: %+v", missing)
+	}
+}
+
+func TestNewUsesDedicatedSourceTransferTimeout(t *testing.T) {
+	cli := New("http://example.com", Options{
+		Timeout:               2 * time.Second,
+		SourceTransferTimeout: 15 * time.Minute,
+	})
+	if cli.http.Timeout != 2*time.Second {
+		t.Fatalf("control timeout = %s, want 2s", cli.http.Timeout)
+	}
+	if cli.sourceHTTP.Timeout != 15*time.Minute {
+		t.Fatalf("source timeout = %s, want 15m", cli.sourceHTTP.Timeout)
+	}
+}
+
+func TestNewUsesDefaultControlAndSourceTransferTimeouts(t *testing.T) {
+	t.Parallel()
+
+	cli := New("http://example.com", Options{})
+	if cli.http.Timeout != 30*time.Second || cli.sourceHTTP.Timeout != 15*time.Minute {
+		t.Fatalf("default timeouts control=%s source=%s", cli.http.Timeout, cli.sourceHTTP.Timeout)
 	}
 }
 
@@ -80,5 +103,32 @@ func TestPutSourceBlobParsesErrorResponse(t *testing.T) {
 	var responseErr *ErrorResponseError
 	if !errors.As(err, &responseErr) || responseErr.Code != "source_blob_too_large" {
 		t.Fatalf("expected source_blob_too_large ErrorResponseError, got %T %v", err, err)
+	}
+}
+
+func TestSourceRequestFallsBackToControlClient(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+	cli := New(server.URL, Options{})
+	cli.sourceHTTP = nil
+	if err := cli.PutSourceBlob(context.Background(), strings.Repeat("a", 64), strings.NewReader("source")); err != nil {
+		t.Fatalf("fallback source request: %v", err)
+	}
+}
+
+func TestPutSourceBlobReturnsRequestConstructionError(t *testing.T) {
+	t.Parallel()
+
+	err := New("://invalid", Options{}).PutSourceBlob(
+		context.Background(),
+		strings.Repeat("a", 64),
+		strings.NewReader("source"),
+	)
+	if err == nil {
+		t.Fatal("expected invalid request URL error")
 	}
 }

--- a/frontend/cli-go/internal/client/types.go
+++ b/frontend/cli-go/internal/client/types.go
@@ -111,7 +111,9 @@ type SourceManifest struct {
 }
 
 type SourceWorkspaceRef struct {
-	RootID string `json:"root_id,omitempty"`
+	RootID   string `json:"root_id,omitempty"`
+	RootPath string `json:"root_path"`
+	WorkDir  string `json:"work_dir"`
 }
 
 type SourceDirectoryListing struct {

--- a/frontend/cli-go/internal/remotesource/sync.go
+++ b/frontend/cli-go/internal/remotesource/sync.go
@@ -28,6 +28,7 @@ type Options struct {
 	Enabled       bool
 	MaxRounds     int
 	WorkspaceRoot string
+	WorkDir       string
 	WorkspaceID   string
 	FileSystem    inputset.FileSystem
 	Uploader      Uploader
@@ -86,6 +87,7 @@ func Execute[T any](ctx context.Context, opts Options, req client.PrepareJobRequ
 
 type roundState struct {
 	root        string
+	workDir     string
 	rootID      string
 	fs          inputset.FileSystem
 	uploader    Uploader
@@ -111,6 +113,14 @@ func newRoundState(opts Options) *roundState {
 		root = absRoot
 	}
 	root = filepath.Clean(root)
+	workDir := strings.TrimSpace(opts.WorkDir)
+	if workDir == "" {
+		workDir = root
+	}
+	if absWorkDir, err := filepath.Abs(workDir); err == nil {
+		workDir = absWorkDir
+	}
+	workDir = filepath.Clean(workDir)
 	rootID := strings.TrimSpace(opts.WorkspaceID)
 	if rootID == "" {
 		rootID = filepath.Base(root)
@@ -128,6 +138,7 @@ func newRoundState(opts Options) *roundState {
 	}
 	return &roundState{
 		root:        root,
+		workDir:     workDir,
 		rootID:      rootID,
 		fs:          sourceFS,
 		uploader:    opts.Uploader,
@@ -140,7 +151,11 @@ func newRoundState(opts Options) *roundState {
 
 func (s *roundState) manifest() *client.SourceManifest {
 	manifest := &client.SourceManifest{
-		WorkspaceRef: &client.SourceWorkspaceRef{RootID: s.rootID},
+		WorkspaceRef: &client.SourceWorkspaceRef{
+			RootID:   s.rootID,
+			RootPath: s.root,
+			WorkDir:  s.workDir,
+		},
 	}
 	if len(s.files) > 0 {
 		manifest.Files = make(map[string]string, len(s.files))

--- a/frontend/cli-go/internal/remotesource/sync_test.go
+++ b/frontend/cli-go/internal/remotesource/sync_test.go
@@ -50,6 +50,7 @@ func TestExecuteExpandsManifestUploadsBlobAndRetries(t *testing.T) {
 	got, err := Execute[string](context.Background(), Options{
 		Enabled:       true,
 		WorkspaceRoot: root,
+		WorkDir:       filepath.Join(root, "db"),
 		WorkspaceID:   "remote",
 		FileSystem:    inputset.OSFileSystem{},
 		Uploader:      uploader,
@@ -80,6 +81,9 @@ func TestExecuteExpandsManifestUploadsBlobAndRetries(t *testing.T) {
 	}
 	if len(manifests) != 2 || manifests[0] == nil || manifests[1] == nil {
 		t.Fatalf("expected source manifests on both calls: %+v", manifests)
+	}
+	if got := manifests[0].WorkspaceRef; got == nil || got.RootPath != root || got.WorkDir != filepath.Join(root, "db") {
+		t.Fatalf("workspace_ref = %+v, want root=%q work_dir=%q", got, root, filepath.Join(root, "db"))
 	}
 	if manifests[1].Files["db/changelog/master.sql"] != hash {
 		t.Fatalf("manifest file hash = %q, want %q", manifests[1].Files["db/changelog/master.sql"], hash)


### PR DESCRIPTION
## Summary

- keep absolute client `root_path`, `work_dir`, and prepare arguments in the remote source-sync contract
- send workspace-relative manifest keys for server-side binding and missing-file diagnostics
- use the selected ref base directory as the logical client work directory
- separate the 30-second control timeout from a 15-minute source blob transfer timeout
- update OpenAPI, ADRs, architecture, user guide, and roadmap

## Backend dependency

- https://github.com/kimak-irmagi/izess/pull/31

## Validation

- `go test ./... -count=1` in `frontend/cli-go`
- remote-source package coverage: 97.5%
- new workspace binding and source-transfer functions: 100% coverage
- existing aggregate coverage of the selected CLI packages remains 92.8% because of unrelated historical auth/provenance branches