### PR TITLE
Fix remote prepare host path binding with local WSL configured

### DIFF
--- a/docs/architecture/remote-source-input-sync-flow.RU.md
+++ b/docs/architecture/remote-source-input-sync-flow.RU.md
@@ -28,6 +28,10 @@ remote backend.
   прикладывает logical client workspace root и effective working directory.
   Admission отображает эти координаты в workspace-relative manifest paths;
   remote runner никогда не открывает client paths напрямую.
+- Настройка WSL для local engine не должна влиять на remote path binding.
+  Преобразование путей в WSL применяется только когда выбранный профиль
+  выполняет запрос через local engine, поэтому remote arguments и workspace
+  context остаются в единой host-native системе координат.
 - Source blob uploads используют отдельный 15-minute transfer timeout; prepare
   control requests сохраняют configured control timeout.
 

--- a/docs/architecture/remote-source-input-sync-flow.md
+++ b/docs/architecture/remote-source-input-sync-flow.md
@@ -26,6 +26,10 @@ Related documents:
   and attaches the logical client workspace root and effective working
   directory. Admission maps those coordinates to workspace-relative manifest
   paths; a remote runner never opens the client paths directly.
+- Local-engine WSL configuration must not affect remote path binding. WSL path
+  conversion is applied only when the selected profile executes against the
+  local engine, so remote arguments and workspace context remain in the same
+  host-native coordinate system.
 - Source blob uploads use a dedicated 15-minute transfer timeout; prepare
   control requests retain the configured control timeout.
 

--- a/docs/roadmap.RU.md
+++ b/docs/roadmap.RU.md
@@ -200,7 +200,8 @@ gantt
   передает абсолютные client coordinates `root_path`/`work_dir`, сохраняет
   абсолютные public prepare arguments, использует отдельный 15-минутный
   source-transfer timeout и работает с gateway-owned admission projection без
-  изменения CLI syntax.
+  изменения CLI syntax. Remote path binding изолирован от local WSL config,
+  поэтому Windows host paths не преобразуются ошибочно в `/mnt/...`.
 - **В работе (базовый CI-template слой)**: GitHub Actions release/e2e пайплайны
   уже активны; более широкие team-шаблоны (например, GitLab и on-prem варианты)
   ещё впереди.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -198,6 +198,8 @@ gantt
   `root_path`/`work_dir` coordinates, retains absolute public prepare arguments,
   uses a dedicated 15-minute source-transfer timeout, and interoperates with
   the gateway-owned admission projection without changing the CLI syntax.
+  Remote path binding is isolated from local WSL configuration, preventing
+  Windows host paths from being rewritten into `/mnt/...` coordinates.
 - **In progress (CI templates baseline)**: GitHub Actions-based release/e2e flows
   are active; broader team templates (e.g., GitLab and on-prem deployment variants)
   are still pending.

--- a/docs/user-guides/remote-source-input-sync.md
+++ b/docs/user-guides/remote-source-input-sync.md
@@ -35,6 +35,11 @@ workspace context identifies the absolute client workspace root and effective
 working directory so admission can map arguments and imports into the
 workspace-relative manifest namespace.
 
+Remote requests always use the invoking host's native path syntax. In
+particular, configuring a Windows profile to run its local engine in WSL does
+not rewrite remote request paths from `C:\...` to `/mnt/c/...`; WSL path
+conversion is scoped to local-engine execution only.
+
 ## Profile Configuration
 
 Remote source sync is enabled by default for remote profiles.

--- a/frontend/cli-go/internal/app/prepare.go
+++ b/frontend/cli-go/internal/app/prepare.go
@@ -478,7 +478,14 @@ func canonicalizeBoundaryPath(path string) string {
 	return pathutil.CanonicalizeBoundaryPath(trimmed)
 }
 
+// buildPathConverter scopes Windows-to-WSL path translation to local-engine
+// execution. Remote requests retain host-native absolute paths so their
+// arguments and source workspace context share the coordinate system required
+// by docs/architecture/remote-source-input-sync-flow.md.
 func buildPathConverter(opts cli.PrepareOptions) func(string) (string, error) {
+	if strings.EqualFold(strings.TrimSpace(opts.Mode), "remote") {
+		return nil
+	}
 	if opts.WSLDistro == "" {
 		return nil
 	}

--- a/frontend/cli-go/internal/app/source_sync_test.go
+++ b/frontend/cli-go/internal/app/source_sync_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/sqlrs/cli/internal/cli"
 	"github.com/sqlrs/cli/internal/client"
 	"github.com/sqlrs/cli/internal/inputset"
+	"github.com/sqlrs/cli/internal/pathutil"
 	"github.com/sqlrs/cli/internal/refctx"
 	"github.com/sqlrs/cli/internal/remotesource"
 )
@@ -165,6 +166,52 @@ func TestBuildRemoteSourceSyncOptionsWorkspaceFallbacks(t *testing.T) {
 	fromInvocation, err := buildRemoteSourceSyncOptions(io.Discard, cli.PrepareOptions{Mode: "remote"}, stageRunRequest{invocationCwd: invocation}, nil)
 	if err != nil || fromInvocation.WorkspaceRoot != invocation || fromInvocation.WorkDir != invocation {
 		t.Fatalf("invocation fallback = %+v,%v", fromInvocation, err)
+	}
+}
+
+func TestRemotePreparePreservesHostPathWhenLocalWSLIsConfigured(t *testing.T) {
+	root := t.TempDir()
+	queryPath := filepath.Join(root, "query.sql")
+	if err := os.WriteFile(queryPath, []byte("select 1;\n"), 0o600); err != nil {
+		t.Fatalf("write query.sql: %v", err)
+	}
+
+	binding, err := bindPreparePsqlInputs(
+		cli.PrepareOptions{Mode: "remote", WSLDistro: "Ubuntu"},
+		root,
+		root,
+		prepareArgs{PsqlArgs: []string{"-f", "query.sql"}},
+		nil,
+		strings.NewReader(""),
+	)
+	if err != nil {
+		t.Fatalf("bindPreparePsqlInputs: %v", err)
+	}
+	if binding.cleanup != nil {
+		t.Cleanup(func() { _ = binding.cleanup() })
+	}
+	if len(binding.PsqlArgs) != 2 || !pathutil.SameLocalPath(binding.PsqlArgs[1], queryPath) {
+		t.Fatalf("remote psql args = %q, want host-native path %q", binding.PsqlArgs, queryPath)
+	}
+
+	syncOptions, err := buildRemoteSourceSyncOptions(
+		io.Discard,
+		cli.PrepareOptions{Mode: "remote", WSLDistro: "Ubuntu"},
+		stageRunRequest{workspaceRoot: root, cwd: root},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("buildRemoteSourceSyncOptions: %v", err)
+	}
+	if !pathutil.SameLocalPath(syncOptions.WorkspaceRoot, root) ||
+		!pathutil.SameLocalPath(syncOptions.WorkDir, root) {
+		t.Fatalf("source workspace = root %q, work dir %q; want %q", syncOptions.WorkspaceRoot, syncOptions.WorkDir, root)
+	}
+}
+
+func TestBuildPathConverterRemoteIgnoresLocalWSLConfiguration(t *testing.T) {
+	if converter := buildPathConverter(cli.PrepareOptions{Mode: "remote", WSLDistro: "Ubuntu"}); converter != nil {
+		t.Fatal("remote prepare must not use the local-engine WSL path converter")
 	}
 }
 


### PR DESCRIPTION
## Summary

- scope Windows-to-WSL path conversion to local-engine execution
- preserve native Windows absolute paths in remote prepare requests even when `WSLDistro` is configured
- keep prepare arguments, `workspace_ref.root_path`, and `workspace_ref.work_dir` in one client-native coordinate system
- document the profile boundary in the user guide, architecture flow, and roadmap

## Root cause

`buildPathConverter` enabled WSL conversion whenever `WSLDistro` was present. Remote profiles can inherit that local-engine setting, so `psql -f` was rewritten to `/mnt/c/...` while the remote source manifest correctly retained `C:\...`. Gateway admission then rejected the request because the argument appeared outside the logical workspace root.

## User impact

`sqlrs prepare` against a remote endpoint on Windows no longer fails with `source path ... is outside workspace root` solely because local WSL execution is configured. Local WSL prepare behavior remains unchanged.

## Validation

- `go test ./internal/app -count=1`
- `go test ./... -count=1`
- targeted Windows regression tests for remote host-path preservation and local WSL conversion
- local Windows CLI coverage run completed; cross-platform merged coverage remains enforced by CI