### PR TITLE
Discover bundled engines and complete the Windows release

### DIFF
--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -162,13 +162,29 @@ jobs:
           $env:CGO_ENABLED = "0"
           go build -o "$outDir\\sqlrs-engine${{ matrix.exe }}" ./cmd/sqlrs-engine
 
-      - name: Build local release
+          $linuxOutDir = "${{ github.workspace }}\\${{ env.ENGINE_DIR }}\\linux_${{ matrix.goarch }}"
+          New-Item -ItemType Directory -Force -Path $linuxOutDir | Out-Null
+          $env:GOOS = "linux"
+          go build -o "$linuxOutDir\\sqlrs-engine" ./cmd/sqlrs-engine
+
+      - name: Build local release (unix)
+        if: runner.os != 'Windows'
         run: >
           node scripts/release-local.mjs
           --version "${{ steps.version.outputs.base }}"
           --os "${{ matrix.goos }}"
           --arch "${{ matrix.goarch }}"
           --engine-bin "${{ github.workspace }}/${{ env.ENGINE_DIR }}/${{ matrix.goos }}_${{ matrix.goarch }}/sqlrs-engine${{ matrix.exe }}"
+
+      - name: Build local release (windows)
+        if: runner.os == 'Windows'
+        run: >
+          node scripts/release-local.mjs
+          --version "${{ steps.version.outputs.base }}"
+          --os "${{ matrix.goos }}"
+          --arch "${{ matrix.goarch }}"
+          --engine-bin "${{ github.workspace }}/${{ env.ENGINE_DIR }}/${{ matrix.goos }}_${{ matrix.goarch }}/sqlrs-engine${{ matrix.exe }}"
+          --wsl-engine-bin "${{ github.workspace }}/${{ env.ENGINE_DIR }}/linux_${{ matrix.goarch }}/sqlrs-engine"
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -268,8 +284,6 @@ jobs:
           - platform: linux
             scenario: cache-pressure-chinook
             snapshot_backend: btrfs
-          - platform: windows
-            snapshot_backend: copy
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -468,13 +482,6 @@ jobs:
           name: sqlrs_windows_amd64
           path: rc-artifacts
 
-      - name: Download linux rc artifact for WSL engine
-        if: matrix.platform == 'windows'
-        uses: actions/download-artifact@v4
-        with:
-          name: sqlrs_linux_amd64
-          path: rc-artifacts-linux
-
       - name: Extract linux bundle
         if: matrix.platform == 'linux'
         id: bundle-linux
@@ -495,7 +502,7 @@ jobs:
           fi
           echo "bundle_dir=$bundle_dir" >> "$GITHUB_OUTPUT"
 
-      - name: Extract windows and linux bundles
+      - name: Extract windows bundle
         if: matrix.platform == 'windows'
         id: bundle-windows
         shell: pwsh
@@ -523,23 +530,14 @@ jobs:
             throw "sqlrs-engine.exe not found in extracted windows bundle"
           }
 
-          $linuxArchive = Get-ChildItem -Path rc-artifacts-linux -Recurse -Filter "sqlrs_${base}_linux_amd64.tar.gz" | Select-Object -First 1
-          if (-not $linuxArchive) {
-            throw "linux release archive for WSL engine not found"
-          }
-          tar -xzf $linuxArchive.FullName -C $bundleRoot
-
           $linuxEngine = Get-ChildItem -Path $bundleRoot -Recurse -File -Filter "sqlrs-engine" |
-            Where-Object { $_.FullName -match "linux_amd64" } |
-            Sort-Object { $_.FullName.Length } |
+            Where-Object { $_.FullName -match "libexec[\\/]linux-amd64[\\/]sqlrs-engine$" } |
             Select-Object -First 1
           if (-not $linuxEngine) {
             throw "linux sqlrs-engine not found in extracted linux bundle"
           }
 
           "sqlrs_bin=$($windowsSqlrs.FullName)" >> $env:GITHUB_OUTPUT
-          "engine_windows_bin=$($windowsEngine.FullName)" >> $env:GITHUB_OUTPUT
-          "engine_linux_bin=$($linuxEngine.FullName)" >> $env:GITHUB_OUTPUT
       - name: Setup Liquibase latest (linux host)
         if: matrix.platform == 'linux' && matrix.scenario == 'hp-lb-jhipster'
         uses: liquibase/setup-liquibase@v2
@@ -628,13 +626,7 @@ jobs:
           $storeRoot = Join-Path $outDir "store"
           $storeImage = Join-Path $storeRoot "btrfs.vhdx"
           $sqlrs = "${{ steps.bundle-windows.outputs.sqlrs_bin }}"
-          $engineWindows = "${{ steps.bundle-windows.outputs.engine_windows_bin }}"
-          $engineLinux = "${{ steps.bundle-windows.outputs.engine_linux_bin }}"
           $isBtrfs = $env:SNAPSHOT_BACKEND -eq "btrfs"
-          $engine = if ($isBtrfs) { $engineLinux } else { $engineWindows }
-          if ([string]::IsNullOrWhiteSpace($engine)) {
-            throw "engine binary path is empty for snapshot backend $env:SNAPSHOT_BACKEND"
-          }
           Remove-Item Env:DOCKER_HOST -ErrorAction SilentlyContinue
           Remove-Item Env:SQLRS_DOCKER_HOST_PATH_STYLE -ErrorAction SilentlyContinue
           Remove-Item Env:SQLRS_STATE_DB -ErrorAction SilentlyContinue
@@ -654,7 +646,6 @@ jobs:
           $initArgs = @(
             "--workspace", $workspaceDir,
             "init", "local",
-            "--engine", $engine,
             "--snapshot", $env:SNAPSHOT_BACKEND
           )
           if ($isBtrfs) {

--- a/.vscode/sqlrs-workspace-config.schema.json
+++ b/.vscode/sqlrs-workspace-config.schema.json
@@ -47,7 +47,7 @@
         },
         "daemonPath": {
           "type": "string",
-          "description": "Path to local engine binary."
+          "description": "Explicit path to the native host sqlrs-engine binary."
         }
       },
       "additionalProperties": false

--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ Build binaries (PowerShell):
 ```powershell
 go build -o dist/bin/sqlrs-engine.exe ./backend/local-engine-go/cmd/sqlrs-engine
 go build -o dist/bin/sqlrs.exe ./frontend/cli-go/cmd/sqlrs
+New-Item -ItemType Directory -Force -Path dist/bin/libexec/linux-amd64 | Out-Null
+$env:GOOS = "linux"
+$env:GOARCH = "amd64"
+$env:CGO_ENABLED = "0"
+go build -o dist/bin/libexec/linux-amd64/sqlrs-engine ./backend/local-engine-go/cmd/sqlrs-engine
+Remove-Item Env:GOOS
+Remove-Item Env:GOARCH
+Remove-Item Env:CGO_ENABLED
 ```
 
 Initialize WSL + btrfs (loopback image) and write workspace config:
@@ -180,6 +188,9 @@ Initialize WSL + btrfs (loopback image) and write workspace config:
 Notes:
 
 - `sqlrs init local --snapshot btrfs` validates WSL, resolves the distro, and ensures the WSL state dir is on **btrfs**.
+- The Windows distribution contains `sqlrs-engine.exe` for native copy mode and
+  a Linux engine payload for WSL2/btrfs. Normal release users do not need to
+  configure either path.
 - The current implementation creates a host VHDX at `%LOCALAPPDATA%\\sqlrs\\store\\btrfs.vhdx`, formats it as btrfs inside WSL, and mounts it to `~/.local/state/sqlrs/store`.
 - If WSL or btrfs is missing, `sqlrs init local --snapshot btrfs` fails. Use `sqlrs init local --snapshot auto` to allow fallback to the Windows host engine with copy snapshots.
 - Use `--no-start` to skip auto-starting the WSL distro during init.

--- a/docs/adr/2026-08-22-local-engine-binary-discovery.md
+++ b/docs/adr/2026-08-22-local-engine-binary-discovery.md
@@ -1,6 +1,6 @@
 # ADR: Local engine binary discovery and Windows bundle composition
 
-Status: Proposed
+Status: Accepted
 Date: 2026-08-22
 
 ## Decision Record 1: Resolve local engines without mandatory configuration

--- a/docs/adr/2026-08-22-local-engine-binary-discovery.md
+++ b/docs/adr/2026-08-22-local-engine-binary-discovery.md
@@ -17,10 +17,10 @@ Date: 2026-08-22
   - Resolve explicit overrides first, then discover binaries relative to the
     running CLI release bundle, with `PATH` as a native-host fallback.
 - Decision: Keep explicit configuration optional. Resolve the native host engine
-  from `--engine`/config, then `SQLRS_DAEMON_PATH`, then the bundle containing
-  the running CLI, and finally `PATH`. Resolve the Windows WSL payload
-  independently from `--wsl-engine`/the provisioned config,
-  `SQLRS_WSL_ENGINE_PATH`, and then the CLI bundle. Do not introduce
+  from `--engine`, then `SQLRS_DAEMON_PATH`, persisted config, the bundle
+  containing the running CLI, and finally `PATH`. Resolve the Windows WSL
+  payload independently from `--wsl-engine`, `SQLRS_WSL_ENGINE_PATH`, the
+  provisioned config, and then the CLI bundle. Do not introduce
   `SQLRS_HOME` for executable discovery.
 - Rationale: A release bundle should work after extraction without per-workspace
   paths, while explicit overrides remain available for development and custom

--- a/docs/adr/2026-08-22-local-engine-binary-discovery.md
+++ b/docs/adr/2026-08-22-local-engine-binary-discovery.md
@@ -1,0 +1,71 @@
+# ADR: Local engine binary discovery and Windows bundle composition
+
+Status: Proposed
+Date: 2026-08-22
+
+## Decision Record 1: Resolve local engines without mandatory configuration
+
+- Timestamp: 2026-08-22T16:38:14+07:00
+- User: @evilguest
+- Agent: Codex (GPT-5)
+- Question: How should `sqlrs` find a local engine when `sqlrs init local` is
+  invoked without an explicit engine reference?
+- Alternatives:
+  - Require a new `SQLRS_HOME` variable and resolve binaries below it.
+  - Require an engine environment variable such as `SQLRS_ENGINE`.
+  - Search only `PATH` for `sqlrs-engine`.
+  - Resolve explicit overrides first, then discover binaries relative to the
+    running CLI release bundle, with `PATH` as a native-host fallback.
+- Decision: Keep explicit configuration optional. Resolve the native host engine
+  from `--engine`/config, then `SQLRS_DAEMON_PATH`, then the bundle containing
+  the running CLI, and finally `PATH`. Resolve the Windows WSL payload
+  independently from `--wsl-engine`/the provisioned config,
+  `SQLRS_WSL_ENGINE_PATH`, and then the CLI bundle. Do not introduce
+  `SQLRS_HOME` for executable discovery.
+- Rationale: A release bundle should work after extraction without per-workspace
+  paths, while explicit overrides remain available for development and custom
+  installations. Separating the host and WSL paths removes the existing
+  ambiguity where one daemon path could not describe both binaries.
+
+## Decision Record 2: Ship both engines in the Windows release
+
+- Timestamp: 2026-08-22T16:38:14+07:00
+- User: @evilguest
+- Agent: Codex (GPT-5)
+- Question: Does the Windows release need both a native Windows engine and a
+  Linux engine?
+- Alternatives:
+  - Ship only the Linux engine and require WSL2 for every local workflow.
+  - Ship only the Windows engine and remove WSL2/btrfs support.
+  - Ship both engines and select the runtime from the resolved snapshot backend.
+- Decision: Ship `sqlrs.exe`, `sqlrs-engine.exe`, and a same-architecture Linux
+  engine under `libexec/linux-<arch>/sqlrs-engine`. Use the Linux engine for
+  WSL2/btrfs and the Windows engine for copy snapshots or automatic host
+  fallback. During WSL init, copy the Linux payload into the selected distro and
+  record its installed Linux path.
+- Rationale: Docker Desktop exposes its engine to Windows clients even when its
+  own backend uses WSL2, so the native engine remains useful without requiring a
+  user-managed WSL distribution. Shipping both binaries also preserves the
+  documented copy fallback while enabling the preferred WSL2/btrfs path.
+
+## Decision Record 3: Validate before writing and repair derived provisioning
+
+- Timestamp: 2026-08-22T16:38:14+07:00
+- User: @evilguest
+- Agent: Codex (GPT-5)
+- Question: How should init behave when engine discovery or a previous WSL
+  provisioning attempt is incomplete?
+- Alternatives:
+  - Write workspace configuration first and report missing engines later.
+  - Require users to delete `.sqlrs` and initialize again.
+  - Validate required bundle inputs before configuration writes and allow a
+    repeated init to repair the derived WSL engine installation.
+- Decision: Validate all binaries required by the selected runtime before
+  creating or updating workspace configuration. Keep the existing configuration
+  unchanged on validation or provisioning failure. A repeated
+  `sqlrs init local` may restore a missing provisioned Linux engine without
+  `--update`, because that copy is derived runtime state rather than user-owned
+  configuration.
+- Rationale: Initialization must not leave a workspace marker that prevents a
+  user from completing setup after correcting permissions or elevation. Safe,
+  idempotent repair removes the need for manual workspace deletion.

--- a/docs/architecture/README.RU.md
+++ b/docs/architecture/README.RU.md
@@ -32,6 +32,10 @@
   границы CLI auth packages, credential storage и владение данными.
 - [`cli-component-structure.RU.md`](cli-component-structure.RU.md) - внутренняя
   структура CLI.
+- [`local-engine-binary-discovery-flow.RU.md`](local-engine-binary-discovery-flow.RU.md) -
+  discovery локального engine, Windows dual-engine bundle и WSL provisioning.
+- [`local-engine-binary-discovery-component-structure.RU.md`](local-engine-binary-discovery-component-structure.RU.md) -
+  package boundaries и владение данными для discovery engine binaries.
 - [`inputset-component-structure.RU.md`](inputset-component-structure.RU.md) -
   общий CLI-side слой input set для file-bearing семантики команд.
 - [`local-engine-component-structure.RU.md`][lecs] -

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -31,6 +31,10 @@ Entry points for Taidon architecture and service design.
   auth package boundaries, credential storage, and data ownership.
 - [`cli-component-structure.md`](cli-component-structure.md) - CLI internal
   component structure.
+- [`local-engine-binary-discovery-flow.md`](local-engine-binary-discovery-flow.md) -
+  local engine discovery, Windows dual-engine bundle, and WSL provisioning flow.
+- [`local-engine-binary-discovery-component-structure.md`](local-engine-binary-discovery-component-structure.md) -
+  package boundaries and data ownership for engine binary discovery.
 - [`inputset-component-structure.md`](inputset-component-structure.md) - shared
   CLI-side input-set layer for file-bearing command semantics.
 - [`local-engine-component-structure.md`](local-engine-component-structure.md) -

--- a/docs/architecture/cli-component-structure.RU.md
+++ b/docs/architecture/cli-component-structure.RU.md
@@ -108,6 +108,11 @@
     refresh token-ами или cached ID token-ами.
 - `internal/paths`
   - OS-aware разрешение директорий config/cache/state.
+- `internal/enginebin`
+  - Разрешает native и Windows WSL companion engine binaries из explicit
+    overrides, environment, bundle запущенного CLI и native `PATH` fallback.
+  - Проверяет executable format и target architecture, не читая config, не
+    выполняя WSL-команды и не сохраняя state.
 - `internal/wsl`
   - Примитивы определения WSL и выбора дистрибутива, которые `internal/app`
     использует для `init local` и Windows local mode.
@@ -216,6 +221,7 @@ flowchart LR
   DAEMON["internal/daemon"]
   CONFIG["internal/config"]
   PATHS["internal/paths"]
+  ENGINEBIN["internal/enginebin"]
   WSL["internal/wsl"]
   UTIL["internal/util"]
   FS["workspace filesystem"]
@@ -228,6 +234,7 @@ flowchart LR
   APP --> REFCTX
   APP --> CONFIG
   APP --> PATHS
+  APP --> ENGINEBIN
   APP --> WSL
   APP --> UTIL
   AUTH --> CONFIG

--- a/docs/architecture/cli-component-structure.md
+++ b/docs/architecture/cli-component-structure.md
@@ -105,6 +105,11 @@ addition of a shared `inputset` layer for file-bearing command semantics.
     refresh tokens or cached ID tokens.
 - `internal/paths`
   - OS-aware config/cache/state directory resolution.
+- `internal/enginebin`
+  - Resolves native and Windows WSL companion engine binaries from explicit
+    overrides, environment, the running CLI bundle, and native `PATH` fallback.
+  - Validates executable format and target architecture without reading config,
+    running WSL commands, or persisting state.
 - `internal/wsl`
   - WSL detection and distro resolution primitives used by `internal/app` for
     `init local` and Windows local mode.
@@ -212,6 +217,7 @@ flowchart LR
   DAEMON["internal/daemon"]
   CONFIG["internal/config"]
   PATHS["internal/paths"]
+  ENGINEBIN["internal/enginebin"]
   WSL["internal/wsl"]
   UTIL["internal/util"]
   FS["workspace filesystem"]
@@ -224,6 +230,7 @@ flowchart LR
   APP --> REFCTX
   APP --> CONFIG
   APP --> PATHS
+  APP --> ENGINEBIN
   APP --> WSL
   APP --> UTIL
   AUTH --> CONFIG

--- a/docs/architecture/local-deployment-architecture.RU.md
+++ b/docs/architecture/local-deployment-architecture.RU.md
@@ -54,6 +54,9 @@ flowchart LR
 - Парсить команды и флаги пользователя
 - Работать с локальной файловой системой (конфиг проекта, пути)
 - Находить или запускать локальный процесс engine
+- Разрешать native engine из explicit config, environment, CLI release bundle
+  или `PATH`; на Windows отдельно разрешать и устанавливать bundled Linux
+  companion для WSL2/btrfs
 - Общаться с engine по HTTP через loopback или Unix socket
 - Выполнять `run` команды локально против подготовленного экземпляра
 - Отклонять remote-only команды управления пользователями и организациями до
@@ -191,6 +194,10 @@ Engine выполняет `psql` внутри DB-контейнера через
 - Engine пишет `engine.json` в Windows state dir и получает путь через `/mnt/...` (WSL path translation)
 - Engine проверяет systemd-маунт `SQLRS_STATE_STORE` при старте (только WSL + btrfs)
 - StateFS backend может откатываться на copy-based стратегию
+- Windows release содержит `sqlrs-engine.exe` для native copy mode и Linux
+  companion в `libexec/linux-<arch>/` для WSL2/btrfs. Discovery и provisioning
+  определены в
+  [`local-engine-binary-discovery-flow.RU.md`](local-engine-binary-discovery-flow.RU.md).
 
 ---
 

--- a/docs/architecture/local-deployment-architecture.md
+++ b/docs/architecture/local-deployment-architecture.md
@@ -54,6 +54,9 @@ flowchart LR
 - Parse user commands and flags
 - Interact with local filesystem (project config, paths)
 - Discover or spawn a local engine process
+- Resolve the native engine from explicit configuration, environment, the CLI
+  release bundle, or `PATH`; on Windows, resolve and provision the bundled Linux
+  companion independently for WSL2/btrfs
 - Communicate with engine via HTTP over loopback or Unix socket
 - Execute `run` commands locally against a prepared instance/instance
 - Reject remote-only user and organization management commands before local
@@ -190,6 +193,10 @@ On Windows (when btrfs is selected):
 - Engine writes `engine.json` to the Windows state directory and receives that path via `/mnt/...` (WSL path translation)
 - Engine verifies the systemd mount for `SQLRS_STATE_STORE` at startup (WSL + btrfs only)
 - StateFS backend may fall back to copy-based strategy
+- The Windows release contains both `sqlrs-engine.exe` for native copy mode and
+  a Linux companion under `libexec/linux-<arch>/` for WSL2/btrfs. Discovery and
+  provisioning are defined in
+  [`local-engine-binary-discovery-flow.md`](local-engine-binary-discovery-flow.md).
 
 ---
 

--- a/docs/architecture/local-engine-binary-discovery-component-structure.RU.md
+++ b/docs/architecture/local-engine-binary-discovery-component-structure.RU.md
@@ -43,7 +43,7 @@ workspace config, не выполняет WSL-команды, не копиру�
 
 - `runInit` определяет нужные runtime binaries из выбора snapshot/store;
 - сборка command context переводит typed config и environment values в
-  `enginebin.Request`;
+  отложенный runtime candidate;
 - package-local WSL provisioning устанавливает найденный Linux source через
   временную копию, executable permissions, проверку установленного файла и
   атомарное переименование;
@@ -70,9 +70,11 @@ engine candidates и не владеет структурой bundle.
 
 ### `internal/daemon`
 
-Получает полностью разрешённую runtime command из `internal/app`. Он по-прежнему
-отвечает за lock, запуск процесса, health polling и `engine.json`, но не за
-discovery executable.
+Получает отложенный runtime candidate из `internal/app`. Он по-прежнему отвечает
+за lock, запуск процесса, health polling и `engine.json`. После финальной
+health-проверки под lock и только когда требуется запустить новый процесс он
+разрешает native host engine через `internal/enginebin` либо проверяет
+настроенный путь установленного WSL engine.
 
 ## Release packaging
 
@@ -112,6 +114,7 @@ flowchart LR
   APP --> CONFIG["internal/config"]
   APP --> WSL["internal/wsl"]
   APP --> DAEMON["internal/daemon"]
+  DAEMON --> ENGINEBIN
   ENGINEBIN --> FS["os / filesystem / PATH"]
   APP --> WSLFS["WSL derived engine installation"]
   PACKAGER["scripts/release-local.mjs"] --> BUNDLE["release bundle"]

--- a/docs/architecture/local-engine-binary-discovery-component-structure.RU.md
+++ b/docs/architecture/local-engine-binary-discovery-component-structure.RU.md
@@ -1,0 +1,122 @@
+# Компонентная структура discovery бинарников локального engine
+
+## Deployment units
+
+Изменение затрагивает два существующих deployment unit:
+
+- `frontend/cli-go`: discovery, проверка, оркестрация WSL provisioning и выбор
+  runtime;
+- release archives из `scripts/release-local.mjs`: неизменяемые native и
+  companion engine payload.
+
+Сам executable локального engine не получает новых обязанностей. API и схема БД
+не меняются.
+
+## CLI packages
+
+### `internal/enginebin`
+
+Владеет platform-neutral политикой discovery и проверки бинарников.
+
+Ключевые типы:
+
+- `Kind`: `Host` или `WSLPayload`;
+- `Origin`: `Explicit`, `Environment`, `Bundle` или `Path`;
+- `Request`: target OS/architecture, путь исполняемого CLI, explicit/config
+  candidate, environment candidate и разрешение `PATH` fallback;
+- `Resolved`: абсолютный source path, kind, origin, обнаруженный executable
+  format и architecture;
+- `Resolver`: разрешает candidates в документированном порядке.
+
+Интерфейсы, внедряемые для тестов:
+
+- resolver executable path (`os.Executable` в production);
+- command lookup (`exec.LookPath` в production);
+- операции inspection/open над filesystem.
+
+Пакет проверяет PE/ELF format и architecture до возврата candidate. Он не читает
+workspace config, не выполняет WSL-команды, не копирует файлы и не хранит state.
+
+### `internal/app`
+
+Сохраняет orchestration ownership:
+
+- `runInit` определяет нужные runtime binaries из выбора snapshot/store;
+- сборка command context переводит typed config и environment values в
+  `enginebin.Request`;
+- package-local WSL provisioning устанавливает найденный Linux source через
+  временную копию, executable permissions, проверку установленного файла и
+  атомарное переименование;
+- существующие WSL bootstrap/storage helpers продолжают владеть lifecycle
+  distro и btrfs.
+
+Путь установки в WSL — `~/.local/lib/sqlrs/sqlrs-engine`. Он сохраняется как
+`engine.wsl.enginePath`. Замена безопасна: неудачная временная копия не заменяет
+предыдущий валидный бинарник.
+
+### `internal/config`
+
+Продолжает владеть parsing и merged configuration. Он предоставляет:
+
+- `orchestrator.daemonPath` как override нативного host engine;
+- `engine.wsl.enginePath` как установленный Linux path внутри WSL.
+
+Discovery в пакет не входит. Новый persisted config key не требуется.
+
+### `internal/wsl`
+
+Продолжает владеть примитивами WSL availability и выбора distro. Он не выбирает
+engine candidates и не владеет структурой bundle.
+
+### `internal/daemon`
+
+Получает полностью разрешённую runtime command из `internal/app`. Он по-прежнему
+отвечает за lock, запуск процесса, health polling и `engine.json`, но не за
+discovery executable.
+
+## Release packaging
+
+`scripts/release-local.mjs` сохраняет `--engine-bin` для native target engine.
+Для Windows target он дополнительно требует:
+
+```text
+--wsl-engine-bin <linux-elf-path>
+```
+
+Packager проверяет ELF companion и кладёт его в
+`libexec/linux-<arch>/sqlrs-engine`. Non-Windows targets отклоняют дополнительный
+аргумент, чтобы не создавать неоднозначные архивы.
+
+Release E2E распаковывает только Windows release archive для Windows scenarios.
+Он обязан проверить наличие обоих engine и использовать bundled companion для
+WSL init. Загрузка отдельного Linux archive больше не считается проверкой
+публикуемого Windows artifact.
+
+## Владение данными
+
+- Immutable release data: CLI, native engine и WSL payload внутри archive.
+- User configuration: `.sqlrs/config.yaml`.
+- Derived global runtime data: `~/.local/lib/sqlrs/sqlrs-engine` внутри
+  выбранного WSL distro.
+- Ephemeral data: списки candidates, результаты validation и временные install
+  paths.
+
+Credentials, engine auth tokens и пользовательские source data не попадают в
+discovery или packaging state.
+
+## Направление зависимостей
+
+```mermaid
+flowchart LR
+  APP["internal/app"] --> ENGINEBIN["internal/enginebin"]
+  APP --> CONFIG["internal/config"]
+  APP --> WSL["internal/wsl"]
+  APP --> DAEMON["internal/daemon"]
+  ENGINEBIN --> FS["os / filesystem / PATH"]
+  APP --> WSLFS["WSL derived engine installation"]
+  PACKAGER["scripts/release-local.mjs"] --> BUNDLE["release bundle"]
+  ENGINEBIN --> BUNDLE
+```
+
+`internal/enginebin` не должен зависеть от `internal/app`, `internal/config`,
+`internal/wsl` или `internal/daemon`.

--- a/docs/architecture/local-engine-binary-discovery-component-structure.RU.md
+++ b/docs/architecture/local-engine-binary-discovery-component-structure.RU.md
@@ -21,7 +21,7 @@
 Ключевые типы:
 
 - `Kind`: `Host` или `WSLPayload`;
-- `Origin`: `Explicit`, `Environment`, `Bundle` или `Path`;
+- `Origin`: `Explicit`, `Environment`, `Config`, `Bundle` или `Path`;
 - `Request`: target OS/architecture, путь исполняемого CLI, explicit/config
   candidate, environment candidate и разрешение `PATH` fallback;
 - `Resolved`: абсолютный source path, kind, origin, обнаруженный executable
@@ -34,7 +34,7 @@
 - command lookup (`exec.LookPath` в production);
 - операции inspection/open над filesystem.
 
-Пакет проверяет PE/ELF format и architecture до возврата candidate. Он не читает
+Пакет проверяет PE, ELF или Mach-O format и architecture до возврата candidate. Он не читает
 workspace config, не выполняет WSL-команды, не копирует файлы и не хранит state.
 
 ### `internal/app`

--- a/docs/architecture/local-engine-binary-discovery-component-structure.md
+++ b/docs/architecture/local-engine-binary-discovery-component-structure.md
@@ -1,0 +1,125 @@
+# Local Engine Binary Discovery Component Structure
+
+## Deployment Units
+
+The change affects two existing deployment units:
+
+- `frontend/cli-go`: discovery, validation, WSL provisioning orchestration, and
+  runtime selection;
+- release archives produced by `scripts/release-local.mjs`: immutable native
+  and companion engine payloads.
+
+The local engine executable itself gains no new responsibility. There are no API
+or database-schema changes.
+
+## CLI Packages
+
+### `internal/enginebin`
+
+Owns platform-neutral binary discovery and validation policy.
+
+Key types:
+
+- `Kind`: `Host` or `WSLPayload`;
+- `Origin`: `Explicit`, `Environment`, `Bundle`, or `Path`;
+- `Request`: target OS/architecture, CLI executable path, explicit/config
+  candidate, environment candidate, and whether `PATH` fallback is allowed;
+- `Resolved`: absolute source path, kind, origin, detected executable format,
+  and architecture;
+- `Resolver`: resolves candidates in documented precedence order.
+
+Key interfaces injected for tests:
+
+- executable-path resolver (`os.Executable` in production);
+- command lookup (`exec.LookPath` in production);
+- filesystem inspection/open operations.
+
+The package validates PE versus ELF format and architecture before returning a
+candidate. It does not read workspace config, execute WSL commands, copy files,
+or persist state.
+
+### `internal/app`
+
+Retains orchestration ownership:
+
+- `runInit` determines which runtime binaries are required from snapshot/store
+  selection;
+- command-context construction maps typed config and environment values into
+  `enginebin.Request`;
+- package-local WSL provisioning installs the resolved Linux source by copying
+  to a temporary file, setting executable permissions, validating the installed
+  file, and atomically renaming it;
+- existing WSL bootstrap/storage helpers remain responsible for distro and
+  btrfs lifecycle.
+
+The WSL installation destination is
+`~/.local/lib/sqlrs/sqlrs-engine`. The installed path is persisted as
+`engine.wsl.enginePath`. Installation is replace-safe; a failed temporary copy
+does not replace a previously valid binary.
+
+### `internal/config`
+
+Continues to own parsing and merged configuration. It exposes:
+
+- `orchestrator.daemonPath` as the native host override;
+- `engine.wsl.enginePath` as the installed Linux path inside WSL.
+
+It does not perform discovery. No new persisted config key is required.
+
+### `internal/wsl`
+
+Continues to own WSL availability and distro-selection primitives. It does not
+choose engine candidates or own bundle layout.
+
+### `internal/daemon`
+
+Receives a fully resolved runtime command from `internal/app`. It remains
+responsible for lock acquisition, process start, health polling, and
+`engine.json`; it does not discover executables.
+
+## Release Packaging
+
+`scripts/release-local.mjs` keeps `--engine-bin` for the native target engine.
+For a Windows target it additionally requires:
+
+```text
+--wsl-engine-bin <linux-elf-path>
+```
+
+The packager validates that the companion is ELF and stages it at
+`libexec/linux-<arch>/sqlrs-engine`. Non-Windows targets reject the additional
+argument to prevent ambiguous archives.
+
+Release E2E extracts only the Windows release archive for Windows scenarios. It
+must assert that both engines exist and must use the bundled companion for WSL
+init. Downloading a separate Linux archive would no longer validate the
+published Windows artifact.
+
+## Data Ownership
+
+- Immutable release data: CLI, native engine, and WSL payload in the archive.
+- User configuration: `.sqlrs/config.yaml`.
+- Derived global runtime data: `~/.local/lib/sqlrs/sqlrs-engine` inside the
+  selected WSL distro.
+- Ephemeral data: candidate lists, validation results, and temporary install
+  paths.
+
+No credentials, engine auth tokens, or submitted source data enter discovery
+or packaging state.
+
+## Dependency Direction
+
+```mermaid
+flowchart LR
+  APP["internal/app"] --> ENGINEBIN["internal/enginebin"]
+  APP --> CONFIG["internal/config"]
+  APP --> WSL["internal/wsl"]
+  APP --> DAEMON["internal/daemon"]
+  ENGINEBIN --> FS["os / filesystem / PATH"]
+  APP --> WSLFS["WSL derived engine installation"]
+  PACKAGER["scripts/release-local.mjs"] --> BUNDLE["release bundle"]
+  ENGINEBIN --> BUNDLE
+```
+
+`internal/enginebin` must not depend on `internal/app`, `internal/config`,
+`internal/wsl`, or `internal/daemon`.

--- a/docs/architecture/local-engine-binary-discovery-component-structure.md
+++ b/docs/architecture/local-engine-binary-discovery-component-structure.md
@@ -21,7 +21,7 @@ Owns platform-neutral binary discovery and validation policy.
 Key types:
 
 - `Kind`: `Host` or `WSLPayload`;
-- `Origin`: `Explicit`, `Environment`, `Bundle`, or `Path`;
+- `Origin`: `Explicit`, `Environment`, `Config`, `Bundle`, or `Path`;
 - `Request`: target OS/architecture, CLI executable path, explicit/config
   candidate, environment candidate, and whether `PATH` fallback is allowed;
 - `Resolved`: absolute source path, kind, origin, detected executable format,
@@ -34,7 +34,7 @@ Key interfaces injected for tests:
 - command lookup (`exec.LookPath` in production);
 - filesystem inspection/open operations.
 
-The package validates PE versus ELF format and architecture before returning a
+The package validates PE, ELF, or Mach-O format and architecture before returning a
 candidate. It does not read workspace config, execute WSL commands, copy files,
 or persist state.
 

--- a/docs/architecture/local-engine-binary-discovery-component-structure.md
+++ b/docs/architecture/local-engine-binary-discovery-component-structure.md
@@ -44,8 +44,8 @@ Retains orchestration ownership:
 
 - `runInit` determines which runtime binaries are required from snapshot/store
   selection;
-- command-context construction maps typed config and environment values into
-  `enginebin.Request`;
+- command-context construction maps typed config and environment values into a
+  deferred runtime candidate;
 - package-local WSL provisioning installs the resolved Linux source by copying
   to a temporary file, setting executable permissions, validating the installed
   file, and atomically renaming it;
@@ -73,9 +73,11 @@ choose engine candidates or own bundle layout.
 
 ### `internal/daemon`
 
-Receives a fully resolved runtime command from `internal/app`. It remains
+Receives a deferred runtime candidate from `internal/app`. It remains
 responsible for lock acquisition, process start, health polling, and
-`engine.json`; it does not discover executables.
+`engine.json`. After the final locked health check and only when a new process
+must be started, it resolves the native host engine through `internal/enginebin`
+or validates the configured installed WSL engine path.
 
 ## Release Packaging
 
@@ -115,6 +117,7 @@ flowchart LR
   APP --> CONFIG["internal/config"]
   APP --> WSL["internal/wsl"]
   APP --> DAEMON["internal/daemon"]
+  DAEMON --> ENGINEBIN
   ENGINEBIN --> FS["os / filesystem / PATH"]
   APP --> WSLFS["WSL derived engine installation"]
   PACKAGER["scripts/release-local.mjs"] --> BUNDLE["release bundle"]

--- a/docs/architecture/local-engine-binary-discovery-flow.RU.md
+++ b/docs/architecture/local-engine-binary-discovery-flow.RU.md
@@ -100,7 +100,7 @@ flowchart TD
 - Ошибка называет требуемый runtime (`host` или `wsl`), все проверенные классы
   источников и подходящий init flag или environment variable.
 - Диагностика может показывать пути, но не токены из `engine.json`.
-- Невалидный explicit candidate немедленно возвращает ошибку без fallback к
+- Невалидный CLI или environment candidate немедленно возвращает ошибку без fallback к
   bundle или `PATH`.
 - Bundle-relative discovery начинается от `os.Executable`, а не от cwd.
 - `PATH` служит fallback только для native engine. Произвольный Linux engine из

--- a/docs/architecture/local-engine-binary-discovery-flow.RU.md
+++ b/docs/architecture/local-engine-binary-discovery-flow.RU.md
@@ -1,0 +1,107 @@
+# Поток обнаружения бинарников локального engine
+
+## Область
+
+Документ определяет, как CLI выбирает и устанавливает исполняемые бинарники
+engine для local-профилей. Он охватывает нативное выполнение в
+Linux/macOS/Windows и WSL2 runtime с CLI на Windows host. HTTP API engine и схемы
+хранения не меняются.
+
+CLI-синтаксис и приоритеты определены в
+[`../user-guides/sqlrs-init.md`](../user-guides/sqlrs-init.md). Решения записаны
+в [`../adr/2026-08-22-local-engine-binary-discovery.md`](../adr/2026-08-22-local-engine-binary-discovery.md).
+
+## Структура релиза
+
+Нативные Linux- и macOS-бандлы содержат CLI и соответствующий нативный engine.
+Windows amd64 бандл содержит:
+
+```text
+sqlrs.exe
+sqlrs-engine.exe
+libexec/
+  linux-amd64/
+    sqlrs-engine
+```
+
+Файлы распакованного релиза — неизменяемые входные данные дистрибутива.
+Установленный в WSL engine является производным runtime-состоянием.
+
+## Инициализация нового workspace
+
+```mermaid
+sequenceDiagram
+  participant User as "Пользователь"
+  participant App as "CLI init orchestration"
+  participant Resolver as "enginebin.Resolver"
+  participant Bundle as "release bundle / PATH"
+  participant WSL as "выбранный WSL distro"
+  participant Config as ".sqlrs/config.yaml"
+
+  User->>App: sqlrs init local
+  App->>App: определить snapshot/store и требования runtime
+  App->>Resolver: разрешить нужные host и/или WSL бинарники
+  Resolver->>Bundle: проверить explicit, env, bundle и PATH candidates
+  Bundle-->>Resolver: проверенные пути и их origins
+  Resolver-->>App: разрешённый набор engine
+  alt выбран WSL-backed btrfs
+    App->>WSL: проверить distro и storage prerequisites
+    App->>WSL: скопировать Linux payload во временный путь
+    App->>WSL: chmod, проверка, атомарное переименование
+    WSL-->>App: установленный Linux path
+  end
+  App->>Config: атомарно записать завершённый workspace config
+  App-->>User: workspace инициализирован
+```
+
+Discovery и проверка формата бинарника выполняются до записи workspace config.
+Отсутствующий payload релиза — ошибка установки, а не повод для capability
+fallback. При `--snapshot auto` отсутствие возможностей WSL/btrfs может выбрать
+нативный Windows runtime с copy, но повреждённый бандл возвращает ошибку.
+
+## Восстановление существующего workspace
+
+Валидный существующий config принадлежит пользователю и не переписывается
+обычным идемпотентным init. Для WSL-backed workspace init также проверяет
+установленный Linux engine:
+
+1. Если файл существует и является совместимым ELF, init завершается без изменений.
+2. Если файл отсутствует или невалиден, init разрешает WSL payload из бандла и
+   атомарно переустанавливает производный файл по настроенному пути.
+3. Если config создан до появления `engine.wsl.enginePath`, init принимает
+   legacy ELF source из `orchestrator.daemonPath`, устанавливает его в WSL и
+   требует `--update` для записи нового установленного пути. Без `--update` он
+   печатает точную команду обновления и не меняет пользовательский config.
+4. Неудачное восстановление оставляет прежний config и прежний валидный engine
+   без изменений.
+
+## Автозапуск обычной командой
+
+```mermaid
+flowchart TD
+  START["Загрузить merged config и выбранный local profile"] --> STATE{"Есть healthy engine.json?"}
+  STATE -->|да| CONNECT["Подключиться к работающему engine"]
+  STATE -->|нет| MODE{"Активен WSL mode?"}
+  MODE -->|нет| HOST["Разрешить native host engine"]
+  HOST --> SPAWNH["Запустить native engine"]
+  MODE -->|да| INSTALLED{"Настроенный WSL engine существует?"}
+  INSTALLED -->|да| SPAWNW["Запустить установленный engine через wsl.exe"]
+  INSTALLED -->|нет| HINT["Ошибка с подсказкой повторить sqlrs init local"]
+  SPAWNH --> CONNECT
+  SPAWNW --> CONNECT
+```
+
+Обычные команды не устанавливают и не восстанавливают бинарники. Поэтому
+`status`, `prepare` и остальные operational-команды не вносят неожиданных
+глобальных изменений.
+
+## Правила ошибок и диагностики
+
+- Ошибка называет требуемый runtime (`host` или `wsl`), все проверенные классы
+  источников и подходящий init flag или environment variable.
+- Диагностика может показывать пути, но не токены из `engine.json`.
+- Невалидный explicit candidate немедленно возвращает ошибку без fallback к
+  bundle или `PATH`.
+- Bundle-relative discovery начинается от `os.Executable`, а не от cwd.
+- `PATH` служит fallback только для native engine. Произвольный Linux engine из
+  Windows host `PATH` не принимается как WSL payload.

--- a/docs/architecture/local-engine-binary-discovery-flow.md
+++ b/docs/architecture/local-engine-binary-discovery-flow.md
@@ -1,0 +1,108 @@
+# Local Engine Binary Discovery Flow
+
+## Scope
+
+This document defines how the CLI selects and provisions executable engine
+binaries for local profiles. It covers native Linux/macOS/Windows execution and
+the Windows-hosted WSL2 runtime. It does not change engine HTTP APIs or storage
+schemas.
+
+The CLI syntax and precedence are defined in
+[`../user-guides/sqlrs-init.md`](../user-guides/sqlrs-init.md). The decision
+record is
+[`../adr/2026-08-22-local-engine-binary-discovery.md`](../adr/2026-08-22-local-engine-binary-discovery.md).
+
+## Release Layout
+
+Native Linux and macOS bundles contain the CLI and matching native engine.
+Windows amd64 bundles contain:
+
+```text
+sqlrs.exe
+sqlrs-engine.exe
+libexec/
+  linux-amd64/
+    sqlrs-engine
+```
+
+The files under the extracted release root are immutable distribution inputs.
+The WSL-installed engine is derived runtime state.
+
+## New Workspace Initialization
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant App as "CLI init orchestration"
+  participant Resolver as "enginebin.Resolver"
+  participant Bundle as "release bundle / PATH"
+  participant WSL as "selected WSL distro"
+  participant Config as ".sqlrs/config.yaml"
+
+  User->>App: sqlrs init local
+  App->>App: resolve snapshot/store and runtime requirements
+  App->>Resolver: resolve required host and/or WSL binaries
+  Resolver->>Bundle: inspect explicit, env, bundle, PATH candidates
+  Bundle-->>Resolver: validated paths with origins
+  Resolver-->>App: resolved engine set
+  alt WSL-backed btrfs selected
+    App->>WSL: validate distro and storage prerequisites
+    App->>WSL: copy Linux payload to a temporary path
+    App->>WSL: chmod, validate, atomically rename
+    WSL-->>App: installed Linux path
+  end
+  App->>Config: atomically write completed workspace config
+  App-->>User: initialized workspace
+```
+
+Discovery and binary-format validation happen before workspace configuration is
+written. A missing release payload is an installation error, not a platform
+capability fallback. With `--snapshot auto`, lack of WSL/btrfs capability may
+select the native Windows copy runtime, but a corrupt bundle is reported.
+
+## Existing Workspace Repair
+
+An existing valid configuration remains user-owned and is not rewritten by
+plain idempotent init. For a WSL-backed workspace, init additionally verifies
+the configured installed Linux engine:
+
+1. If it exists and is a compatible ELF binary, init succeeds without changes.
+2. If it is missing or invalid, init resolves the bundled WSL payload and
+   atomically reinstalls the derived file at the configured path.
+3. If the config predates `engine.wsl.enginePath`, init accepts a legacy ELF
+   source in `orchestrator.daemonPath`, installs it into WSL, and requires
+   `--update` before recording the new installed path. Without `--update`, it
+   prints the exact update command instead of silently changing user config.
+4. A failed repair leaves the prior configuration and prior valid installed
+   engine untouched.
+
+## Normal Command Auto-Start
+
+```mermaid
+flowchart TD
+  START["Load merged config and selected local profile"] --> STATE{"Healthy engine.json?"}
+  STATE -->|yes| CONNECT["Connect to running engine"]
+  STATE -->|no| MODE{"WSL mode active?"}
+  MODE -->|no| HOST["Resolve native host engine"]
+  HOST --> SPAWNH["Spawn native engine"]
+  MODE -->|yes| INSTALLED{"Configured WSL engine exists?"}
+  INSTALLED -->|yes| SPAWNW["Spawn installed engine through wsl.exe"]
+  INSTALLED -->|no| HINT["Fail with: rerun sqlrs init local"]
+  SPAWNH --> CONNECT
+  SPAWNW --> CONNECT
+```
+
+Normal commands do not install or repair binaries. This keeps `status`,
+`prepare`, and other operational commands free of unexpected global mutations.
+
+## Failure and Diagnostic Rules
+
+- Errors identify the required runtime (`host` or `wsl`), every discovery class
+  attempted, and the corrective init flag or environment variable.
+- Diagnostics may show filesystem paths but never tokens from `engine.json`.
+- Explicit invalid candidates fail immediately; they do not silently fall
+  through to bundle or `PATH` discovery.
+- Bundle-relative discovery starts from `os.Executable`, not the current working
+  directory.
+- `PATH` is a fallback for the native engine only. An arbitrary Linux engine on
+  the Windows host `PATH` is not accepted as the WSL payload.

--- a/docs/architecture/local-engine-binary-discovery-flow.md
+++ b/docs/architecture/local-engine-binary-discovery-flow.md
@@ -100,7 +100,7 @@ Normal commands do not install or repair binaries. This keeps `status`,
 - Errors identify the required runtime (`host` or `wsl`), every discovery class
   attempted, and the corrective init flag or environment variable.
 - Diagnostics may show filesystem paths but never tokens from `engine.json`.
-- Explicit invalid candidates fail immediately; they do not silently fall
+- Explicit CLI or environment candidates fail immediately; they do not silently fall
   through to bundle or `PATH` discovery.
 - Bundle-relative discovery starts from `os.Executable`, not the current working
   directory.

--- a/docs/architecture/release-happy-path-e2e.RU.md
+++ b/docs/architecture/release-happy-path-e2e.RU.md
@@ -72,7 +72,9 @@ Release-blocking сценарии для MVP:
 
 1. Maintainer пушит RC tag `vX.Y.Z-rc.N`.
 2. `build_rc` компилирует `sqlrs` и `sqlrs-engine` для всех таргетов и
-   упаковывает бандлы.
+   упаковывает бандлы. Windows archive самодостаточен: он содержит native
+   Windows engine и соответствующий Linux engine payload в
+   `libexec/linux-<arch>/`.
 3. `build_rc` публикует архивы, checksums и `release-manifest.json` как workflow
    artifacts.
 4. `e2e_happy_path` скачивает RC-артефакты и выполняет release-gated матрицу в
@@ -81,6 +83,9 @@ Release-blocking сценарии для MVP:
    - Linux: `hp-psql-chinook`/`hp-psql-sakila` с `copy` и `btrfs`.
    - Windows: `hp-psql-chinook` с `copy` (host engine) и `btrfs`
      (host `sqlrs.exe` + WSL runtime).
+     Обе ячейки распаковывают только публикуемый Windows archive; WSL-ячейка
+     обязана использовать bundled Linux payload, а не отдельно загруженный
+     Linux release.
    - macOS podman probe: `hp-psql-chinook` с `copy`, runtime принудительно
      задается через `container.runtime=podman`, `prepare+run` выполняется дважды
      в одном workspace.

--- a/docs/architecture/release-happy-path-e2e.md
+++ b/docs/architecture/release-happy-path-e2e.md
@@ -71,6 +71,8 @@ Scenario metadata is declared in:
 
 1. Maintainer pushes RC tag `vX.Y.Z-rc.N`.
 2. `build_rc` compiles `sqlrs` and `sqlrs-engine` for all targets and packages bundles.
+   The Windows archive is self-contained: it includes the native Windows engine
+   and the matching Linux engine payload under `libexec/linux-<arch>/`.
 3. `build_rc` publishes archives, checksums, and `release-manifest.json` as
    workflow artifacts.
 4. `e2e_happy_path` downloads RC artifacts and runs release-gated matrix in
@@ -79,6 +81,9 @@ Scenario metadata is declared in:
    - Linux: `hp-psql-chinook`/`hp-psql-sakila` with `copy` and `btrfs`.
    - Windows: `hp-psql-chinook` with `copy` (host engine) and `btrfs`
      (host `sqlrs.exe` + WSL runtime).
+     Both cells extract only the published Windows archive; the WSL cell must
+     use its bundled Linux payload rather than a separately downloaded Linux
+     release.
    - macOS podman probe: `hp-psql-chinook` with `copy`, runtime forced by
      `container.runtime=podman`, with double `prepare+run` pass in one workspace.
      Podman machine startup in this cell is release-blocking.

--- a/docs/roadmap.RU.md
+++ b/docs/roadmap.RU.md
@@ -287,6 +287,10 @@ gantt
   для alias-driven сценариев Chinook, Sakila и Liquibase/JHipster, включая
   Btrfs в матрице валидации и отдельный local cache-pressure сценарий в
   release-проверках)
+- Самодостаточное обнаружение движка в локальном релизе — **сделано** (native
+  engine находится рядом с CLI или через `PATH`; Windows-архив также содержит
+  совместимый Linux engine для WSL, атомарно устанавливает и восстанавливает
+  его при повторном init)
 
 **Опционально (nice-to-have)**:
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -284,6 +284,9 @@ gantt
   Chinook, Sakila, and Liquibase/JHipster alias-driven scenarios, with Btrfs in
   matrix validation and a dedicated local cache-pressure scenario in release
   checks)
+- Self-contained local release discovery — **Done** (native engines are found
+  beside the CLI or on `PATH`; Windows archives also carry and atomically
+  provision the matching Linux engine for WSL, including repeat-init repair)
 
 **Optional (nice-to-have)**:
 

--- a/docs/user-guides/sqlrs-init.md
+++ b/docs/user-guides/sqlrs-init.md
@@ -290,17 +290,19 @@ When btrfs is required, the local engine runs inside WSL2:
 Explicit configuration remains optional for a normal release installation.
 The CLI resolves the native host engine in this order:
 
-1. `--engine` during init, or `orchestrator.daemonPath` after init.
+1. `--engine` during init.
 2. `SQLRS_DAEMON_PATH`.
-3. The platform-native engine in the release bundle containing the running
+3. `orchestrator.daemonPath` from merged configuration.
+4. The platform-native engine in the release bundle containing the running
    `sqlrs` executable.
-4. `sqlrs-engine` (or `sqlrs-engine.exe`) on `PATH`.
+5. `sqlrs-engine` (or `sqlrs-engine.exe`) on `PATH`.
 
 On Windows, the Linux WSL engine payload is resolved independently:
 
-1. `--wsl-engine` during init, or `engine.wsl.enginePath` after provisioning.
+1. `--wsl-engine` during init.
 2. `SQLRS_WSL_ENGINE_PATH`.
-3. `libexec/linux-<arch>/sqlrs-engine` in the release bundle containing the
+3. `engine.wsl.enginePath` after provisioning.
+4. `libexec/linux-<arch>/sqlrs-engine` in the release bundle containing the
    running `sqlrs.exe`.
 
 `SQLRS_HOME` is not used for binary discovery. SQLRS home/state directories own

--- a/docs/user-guides/sqlrs-init.md
+++ b/docs/user-guides/sqlrs-init.md
@@ -174,12 +174,27 @@ or `--snapshot auto` with `--store image|device`).
 
 ### `--engine <path>`
 
-Set the local engine binary path in workspace config.
+Set the native host engine binary path in workspace config.
 
-- Overrides built-in defaults
+- Overrides environment, bundle-relative, and `PATH` discovery
 - Stored in `.sqlrs/config.yaml`
 - If a **relative path** is provided **and** the current working directory is inside the workspace, the path is stored **relative to `.sqlrs/config.yaml`**.
 - Otherwise (absolute path, or `sqlrs init` run outside the workspace via `--workspace`), the path is stored as an **absolute path**.
+
+On Windows this path identifies `sqlrs-engine.exe`, which is used for native
+host execution and the `copy` snapshot fallback. It does not identify the Linux
+engine used inside WSL2.
+
+### `--wsl-engine <path>`
+
+Windows only. Set the Linux engine payload that `sqlrs init local` provisions
+inside the selected WSL2 distribution.
+
+- Overrides `SQLRS_WSL_ENGINE_PATH` and bundle-relative discovery
+- Must identify a Linux ELF binary for the host CPU architecture
+- The source path is not used as the long-lived runtime path: init copies the
+  binary into the WSL distribution and records the installed Linux path in
+  `engine.wsl.enginePath`
 
 ### `--shared-cache`
 
@@ -264,7 +279,40 @@ When btrfs is required, the local engine runs inside WSL2:
 
 - `sqlrs init local` provisions the btrfs store inside the selected distro,
   using a host VHDX by default.
+- The Windows release bundle contains both the native Windows engine and the
+  matching Linux engine payload.
+- Init copies the Linux payload into the selected WSL distribution before it
+  writes a WSL-backed workspace configuration.
 - The CLI records WSL mount metadata in workspace config for validation.
+
+### Engine binary discovery
+
+Explicit configuration remains optional for a normal release installation.
+The CLI resolves the native host engine in this order:
+
+1. `--engine` during init, or `orchestrator.daemonPath` after init.
+2. `SQLRS_DAEMON_PATH`.
+3. The platform-native engine in the release bundle containing the running
+   `sqlrs` executable.
+4. `sqlrs-engine` (or `sqlrs-engine.exe`) on `PATH`.
+
+On Windows, the Linux WSL engine payload is resolved independently:
+
+1. `--wsl-engine` during init, or `engine.wsl.enginePath` after provisioning.
+2. `SQLRS_WSL_ENGINE_PATH`.
+3. `libexec/linux-<arch>/sqlrs-engine` in the release bundle containing the
+   running `sqlrs.exe`.
+
+`SQLRS_HOME` is not used for binary discovery. SQLRS home/state directories own
+mutable configuration and runtime state, while release binaries are discovered
+from explicit overrides or the installation layout.
+
+Before creating a new workspace or changing its configuration, local init
+validates every engine binary required by the selected runtime. If validation or
+WSL provisioning fails, `.sqlrs/config.yaml` remains unchanged. Re-running
+`sqlrs init local` for an existing WSL-backed workspace repairs a missing
+provisioned Linux engine from the bundle without requiring `--update`; this
+repairs a derived runtime artifact and does not change user configuration.
 
 ### macOS
 

--- a/docs/user-guides/sqlrs-local-engine-wsl.md
+++ b/docs/user-guides/sqlrs-local-engine-wsl.md
@@ -89,7 +89,23 @@ The Windows local bundle **includes**:
 - Windows engine binary
 - Linux engine binary (same CPU arch)
 
-`sqlrs init local` copies the Linux engine binary into the WSL distro on first run.
+The bundle layout is:
+
+```text
+sqlrs.exe
+sqlrs-engine.exe
+libexec/
+  linux-amd64/
+    sqlrs-engine
+```
+
+The architecture segment follows the release target (for example,
+`linux-arm64` for a future Windows arm64 bundle).
+
+`sqlrs init local` copies the Linux engine binary into the WSL distro on first
+run and repairs that installed copy when a subsequent init finds it missing.
+The native Windows engine remains the runtime for copy snapshots and for the
+automatic fallback when WSL2-backed btrfs is unavailable.
 
 ### B) btrfs volume lifecycle
 
@@ -208,13 +224,19 @@ If any condition fails: **error** (no fallback).
 
 `engine.wsl.enginePath`
 
-- default: auto (see binary provisioning below).
+- records the installed path inside the selected WSL distribution,
+- is populated after the bundled Linux payload is copied into WSL,
+- can be sourced explicitly during init with `--wsl-engine` or
+  `SQLRS_WSL_ENGINE_PATH`.
 
 ### 4.1 Orchestrator daemon path (host)
 
-`orchestrator.daemonPath` points to the **linux** engine binary in the host bundle.
-When launching inside WSL, the CLI converts this host path to a `/mnt/...` path
-and passes it to `wsl.exe` to start the engine.
+`orchestrator.daemonPath` points to the native host engine. On Windows this is
+`sqlrs-engine.exe`; it is used for copy snapshots and host fallback. It does not
+double as the Linux WSL payload path.
+
+When WSL mode is active, the CLI instead starts the installed Linux path from
+`engine.wsl.enginePath` through `wsl.exe`.
 
 ### 5) Host store path (Windows)
 

--- a/frontend/cli-go.md
+++ b/frontend/cli-go.md
@@ -359,8 +359,8 @@ Start daemon:
 
 The native local engine is resolved from, in order:
 
-1. `orchestrator.daemonPath` in config.
-2. `SQLRS_DAEMON_PATH`.
+1. `SQLRS_DAEMON_PATH`.
+2. `orchestrator.daemonPath` in config.
 3. The native engine in the release bundle containing the running CLI.
 4. `sqlrs-engine` on `PATH`.
 

--- a/frontend/cli-go.md
+++ b/frontend/cli-go.md
@@ -357,12 +357,16 @@ Start daemon:
 
 ### 6.4 How to spawn the daemon
 
-Assumption for MVP:
+The native local engine is resolved from, in order:
 
-- Local service binary path is configured or discoverable.
-- Provide config key or env:
-  - SQLRS_DAEMON_PATH (preferred)
-  - or orchestrator.daemonPath in config
+1. `orchestrator.daemonPath` in config.
+2. `SQLRS_DAEMON_PATH`.
+3. The native engine in the release bundle containing the running CLI.
+4. `sqlrs-engine` on `PATH`.
+
+On Windows, the WSL Linux payload is resolved and provisioned independently as
+defined in `docs/user-guides/sqlrs-init.md`. `orchestrator.daemonPath` always
+means the native host engine.
 
 Spawn:
 
@@ -374,9 +378,9 @@ Spawn:
   `--write-engine-json <path>`
 - Service is responsible for creating engine.json when ready.
 
-If daemonPath missing:
-
-- connect-or-start should error clearly: "local daemon path is not configured".
+If discovery finds no compatible engine, connect-or-start reports the required
+runtime, attempted discovery sources, and a corrective init flag or environment
+variable.
 
 ## 7. HTTP API contract (client side)
 
@@ -498,7 +502,6 @@ Integration tests (optional for MVP):
   - local:
 
     ```bash
-    export SQLRS_DAEMON_PATH=/path/to/sqlrs-service
     sqlrs status
     sqlrs run -- psql -c "select 1"
     ```

--- a/frontend/cli-go/README.md
+++ b/frontend/cli-go/README.md
@@ -51,8 +51,9 @@ node scripts/build-cli-go.mjs
 
 ## Release packaging (local variant)
 
-The local release bundles `sqlrs` and `sqlrs-engine` into archives under
-`dist/release/`.
+The local release bundles `sqlrs` and its native `sqlrs-engine` into archives
+under `dist/release/`. A Windows archive additionally bundles the matching Linux
+engine payload for WSL2 under `libexec/linux-<arch>/sqlrs-engine`.
 
 Provide a platform-specific engine binary per target, for example:
 
@@ -64,6 +65,12 @@ Build an archive:
 
 ```bash
 node scripts/release-local.mjs --version v0.1.0 --os linux --arch amd64 --engine-bin dist/engine/linux_amd64/sqlrs-engine
+```
+
+Windows packaging additionally requires the Linux companion:
+
+```powershell
+node scripts/release-local.mjs --version v0.1.0 --os windows --arch amd64 --engine-bin dist/engine/windows_amd64/sqlrs-engine.exe --wsl-engine-bin dist/engine/linux_amd64/sqlrs-engine
 ```
 
 ## Test

--- a/frontend/cli-go/internal/app/app_wsl_test.go
+++ b/frontend/cli-go/internal/app/app_wsl_test.go
@@ -30,9 +30,10 @@ func TestResolveWSLSettingsUsesConfig(t *testing.T) {
 	cfg := config.Config{
 		Engine: config.EngineConfig{
 			WSL: config.EngineWSLConfig{
-				Mode:     "auto",
-				Distro:   "Ubuntu",
-				StateDir: "/var/lib/sqlrs/store",
+				Mode:       "auto",
+				Distro:     "Ubuntu",
+				StateDir:   "/var/lib/sqlrs/store",
+				EnginePath: "/home/user/.local/lib/sqlrs/sqlrs-engine",
 			},
 		},
 	}
@@ -53,7 +54,7 @@ func TestResolveWSLSettingsUsesConfig(t *testing.T) {
 	if statePath != "/mnt/c/sqlrs/state/engine.json" {
 		t.Fatalf("unexpected statePath: %s", statePath)
 	}
-	if daemonPath != "/mnt/c/sqlrs/bin/sqlrs-engine" {
+	if daemonPath != "/home/user/.local/lib/sqlrs/sqlrs-engine" {
 		t.Fatalf("unexpected daemonPath: %s", daemonPath)
 	}
 	if mountDevice != "" || mountFSType != "" {

--- a/frontend/cli-go/internal/app/command_context.go
+++ b/frontend/cli-go/internal/app/command_context.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/sqlrs/cli/internal/cli"
 	"github.com/sqlrs/cli/internal/config"
-	"github.com/sqlrs/cli/internal/enginebin"
 )
 
 // commandContext centralizes shared CLI command wiring defined in
@@ -37,10 +36,6 @@ type commandContext struct {
 	idleTimeout          time.Duration
 	startupTimeout       time.Duration
 	verbose              bool
-}
-
-var resolveHostEngineFn = func(req enginebin.Request) (enginebin.Resolved, error) {
-	return (enginebin.Resolver{}).Resolve(req)
 }
 
 // resolveCommandContext resolves config, profile, runtime paths, and output mode
@@ -148,20 +143,6 @@ func resolveCommandContext(cwd string, opts cli.GlobalOptions) (commandContext, 
 			return result, err
 		}
 	}
-	if mode == "local" && wslDistro == "" {
-		resolved, resolveErr := resolveHostEngineFn(enginebin.Request{
-			Kind:            enginebin.KindHost,
-			TargetOS:        runtime.GOOS,
-			TargetArch:      runtime.GOARCH,
-			EnvironmentPath: environmentDaemonPath,
-			ConfigPath:      configuredDaemonPath,
-		})
-		if resolveErr != nil {
-			return result, fmt.Errorf("resolve host engine: %w", resolveErr)
-		}
-		daemonPath = resolved.Path
-	}
-
 	result.profileName = profileName
 	result.profile = profile
 	result.mode = mode

--- a/frontend/cli-go/internal/app/command_context.go
+++ b/frontend/cli-go/internal/app/command_context.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/sqlrs/cli/internal/cli"
 	"github.com/sqlrs/cli/internal/config"
+	"github.com/sqlrs/cli/internal/enginebin"
 )
 
 // commandContext centralizes shared CLI command wiring defined in
@@ -127,6 +128,15 @@ func resolveCommandContext(cwd string, opts cli.GlobalOptions) (commandContext, 
 	daemonPath := os.Getenv("SQLRS_DAEMON_PATH")
 	if daemonPath == "" {
 		daemonPath = cfg.Orchestrator.DaemonPath
+	}
+	if strings.TrimSpace(daemonPath) == "" && mode == "local" {
+		if resolved, resolveErr := (enginebin.Resolver{}).Resolve(enginebin.Request{
+			Kind:       enginebin.KindHost,
+			TargetOS:   runtime.GOOS,
+			TargetArch: runtime.GOARCH,
+		}); resolveErr == nil {
+			daemonPath = resolved.Path
+		}
 	}
 	engineRunDir := ""
 	engineStatePath := ""

--- a/frontend/cli-go/internal/app/command_context.go
+++ b/frontend/cli-go/internal/app/command_context.go
@@ -39,6 +39,10 @@ type commandContext struct {
 	verbose              bool
 }
 
+var resolveHostEngineFn = func(req enginebin.Request) (enginebin.Resolved, error) {
+	return (enginebin.Resolver{}).Resolve(req)
+}
+
 // resolveCommandContext resolves config, profile, runtime paths, and output mode
 // once for the whole CLI invocation as described by the maintainability refactor design.
 func resolveCommandContext(cwd string, opts cli.GlobalOptions) (commandContext, error) {
@@ -125,18 +129,11 @@ func resolveCommandContext(cwd string, opts cli.GlobalOptions) (commandContext, 
 		runDir = filepath.Join(cfgResult.Paths.StateDir, "run")
 	}
 
-	daemonPath := os.Getenv("SQLRS_DAEMON_PATH")
+	environmentDaemonPath := strings.TrimSpace(os.Getenv("SQLRS_DAEMON_PATH"))
+	configuredDaemonPath := strings.TrimSpace(cfg.Orchestrator.DaemonPath)
+	daemonPath := environmentDaemonPath
 	if daemonPath == "" {
-		daemonPath = cfg.Orchestrator.DaemonPath
-	}
-	if strings.TrimSpace(daemonPath) == "" && mode == "local" {
-		if resolved, resolveErr := (enginebin.Resolver{}).Resolve(enginebin.Request{
-			Kind:       enginebin.KindHost,
-			TargetOS:   runtime.GOOS,
-			TargetArch: runtime.GOARCH,
-		}); resolveErr == nil {
-			daemonPath = resolved.Path
-		}
+		daemonPath = configuredDaemonPath
 	}
 	engineRunDir := ""
 	engineStatePath := ""
@@ -150,6 +147,19 @@ func resolveCommandContext(cwd string, opts cli.GlobalOptions) (commandContext, 
 		if err != nil {
 			return result, err
 		}
+	}
+	if mode == "local" && wslDistro == "" {
+		resolved, resolveErr := resolveHostEngineFn(enginebin.Request{
+			Kind:            enginebin.KindHost,
+			TargetOS:        runtime.GOOS,
+			TargetArch:      runtime.GOARCH,
+			EnvironmentPath: environmentDaemonPath,
+			ConfigPath:      configuredDaemonPath,
+		})
+		if resolveErr != nil {
+			return result, fmt.Errorf("resolve host engine: %w", resolveErr)
+		}
+		daemonPath = resolved.Path
 	}
 
 	result.profileName = profileName

--- a/frontend/cli-go/internal/app/engine_discovery_regression_test.go
+++ b/frontend/cli-go/internal/app/engine_discovery_regression_test.go
@@ -1,0 +1,234 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/sqlrs/cli/internal/cli"
+	"github.com/sqlrs/cli/internal/enginebin"
+)
+
+var defaultTestHostResolver = func(req enginebin.Request) (enginebin.Resolved, error) {
+	for _, candidate := range []struct {
+		path   string
+		origin enginebin.Origin
+	}{
+		{req.ExplicitPath, enginebin.OriginExplicit},
+		{req.EnvironmentPath, enginebin.OriginEnvironment},
+		{req.ConfigPath, enginebin.OriginConfig},
+	} {
+		if strings.TrimSpace(candidate.path) != "" {
+			return enginebin.Resolved{Path: candidate.path, Kind: enginebin.KindHost, Origin: candidate.origin}, nil
+		}
+	}
+	return enginebin.Resolved{Path: filepath.Join(os.TempDir(), "sqlrs-engine"), Kind: enginebin.KindHost, Origin: enginebin.OriginBundle}, nil
+}
+
+func TestMain(m *testing.M) {
+	resolveHostEngineFn = defaultTestHostResolver
+	os.Exit(m.Run())
+}
+
+func withHostResolver(t *testing.T, fn func(enginebin.Request) (enginebin.Resolved, error)) {
+	t.Helper()
+	previous := resolveHostEngineFn
+	resolveHostEngineFn = fn
+	t.Cleanup(func() { resolveHostEngineFn = previous })
+}
+
+func TestRunInitRejectsMissingHostEngineBeforeWritingConfig(t *testing.T) {
+	workspace := t.TempDir()
+	withHostResolver(t, func(req enginebin.Request) (enginebin.Resolved, error) {
+		if req.Kind != enginebin.KindHost {
+			t.Fatalf("kind=%q, want host", req.Kind)
+		}
+		return enginebin.Resolved{}, errors.New("host engine was not found")
+	})
+
+	var out bytes.Buffer
+	err := runInit(&out, workspace, "", []string{"local", "--snapshot", "copy"}, false)
+	if err == nil || !strings.Contains(err.Error(), "Invalid host engine") {
+		t.Fatalf("expected host discovery error, got %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(workspace, ".sqlrs")); !os.IsNotExist(statErr) {
+		t.Fatalf("workspace marker must not be written, stat err=%v", statErr)
+	}
+}
+
+func TestResolveCommandContextValidatesConfiguredHostCandidate(t *testing.T) {
+	temp := t.TempDir()
+	setTestDirs(t, temp)
+	marker := filepath.Join(temp, ".sqlrs")
+	if err := os.MkdirAll(marker, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configured := filepath.Join(temp, "wrong-platform-engine")
+	configData := []byte("profiles:\n  local:\n    mode: local\norchestrator:\n  daemonPath: " + configured + "\n")
+	if err := os.WriteFile(filepath.Join(marker, "config.yaml"), configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withHostResolver(t, func(req enginebin.Request) (enginebin.Resolved, error) {
+		if req.ConfigPath != configured {
+			t.Fatalf("config candidate=%q, want %q", req.ConfigPath, configured)
+		}
+		return enginebin.Resolved{}, errors.New("format elf is incompatible with windows")
+	})
+
+	_, err := resolveCommandContext(temp, cli.GlobalOptions{})
+	if err == nil || !strings.Contains(err.Error(), "resolve host engine") {
+		t.Fatalf("expected validated host-engine error, got %v", err)
+	}
+}
+
+func TestRunInitDoesNotAttemptWSLRepairOutsideWindows(t *testing.T) {
+	previousWindows := isWindows
+	isWindows = false
+	t.Cleanup(func() { isWindows = previousWindows })
+
+	workspace := t.TempDir()
+	marker := filepath.Join(workspace, ".sqlrs")
+	if err := os.MkdirAll(marker, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	configData := []byte("engine:\n  wsl:\n    mode: required\n    distro: Ubuntu\n    enginePath: /home/user/.local/lib/sqlrs/sqlrs-engine\n")
+	configPath := filepath.Join(marker, "config.yaml")
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousCheck := runWSLCommandAllowFailureFn
+	runWSLCommandAllowFailureFn = func(context.Context, string, bool, string, string, ...string) (string, error) {
+		t.Fatal("non-Windows init attempted WSL repair")
+		return "", nil
+	}
+	t.Cleanup(func() { runWSLCommandAllowFailureFn = previousCheck })
+
+	var out bytes.Buffer
+	if err := runInit(&out, workspace, "", []string{"local"}, false); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+}
+
+func TestRunInitRepairsExecutableButInvalidWSLEngine(t *testing.T) {
+	withWindowsMode(t)
+	workspace := t.TempDir()
+	marker := filepath.Join(workspace, ".sqlrs")
+	if err := os.MkdirAll(marker, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const installed = "/home/user/.local/lib/sqlrs/sqlrs-engine"
+	configData := []byte("engine:\n  wsl:\n    mode: required\n    distro: Ubuntu\n    enginePath: " + installed + "\n")
+	if err := os.WriteFile(filepath.Join(marker, "config.yaml"), configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousValidate := validateInstalledWSLEngineFn
+	validateInstalledWSLEngineFn = func(context.Context, string, string, bool) error {
+		return errors.New("invalid ELF architecture")
+	}
+	t.Cleanup(func() { validateInstalledWSLEngineFn = previousValidate })
+	previousResolver := resolveWSLPayloadFn
+	source := filepath.Join(t.TempDir(), "sqlrs-engine")
+	if err := os.WriteFile(source, []byte("payload"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	resolveWSLPayloadFn = func(string) (enginebin.Resolved, error) {
+		return enginebin.Resolved{Path: source, Kind: enginebin.KindWSLPayload}, nil
+	}
+	t.Cleanup(func() { resolveWSLPayloadFn = previousResolver })
+	previousInstall := runWSLCommandWithInputFn
+	installCalls := 0
+	runWSLCommandWithInputFn = func(_ context.Context, _ string, _ bool, _ string, _ string, _ string, _ ...string) (string, error) {
+		installCalls++
+		return installed + "\n", nil
+	}
+	t.Cleanup(func() { runWSLCommandWithInputFn = previousInstall })
+
+	var out bytes.Buffer
+	if err := runInit(&out, workspace, "", []string{"local"}, false); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	if installCalls != 1 {
+		t.Fatalf("install calls=%d, want 1", installCalls)
+	}
+}
+
+func TestRunInitLegacyWSLRequiresUpdateWithoutChangingConfig(t *testing.T) {
+	withWindowsMode(t)
+	workspace := t.TempDir()
+	marker := filepath.Join(workspace, ".sqlrs")
+	if err := os.MkdirAll(marker, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	legacy := filepath.Join(workspace, "legacy", "sqlrs-engine")
+	if err := os.MkdirAll(filepath.Dir(legacy), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	writeTestELF(t, legacy)
+	configData := []byte("orchestrator:\n  daemonPath: ../legacy/sqlrs-engine\nengine:\n  wsl:\n    mode: required\n    distro: Ubuntu\n")
+	configPath := filepath.Join(marker, "config.yaml")
+	if err := os.WriteFile(configPath, configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	previousResolver := resolveWSLPayloadFn
+	resolveWSLPayloadFn = func(string) (enginebin.Resolved, error) {
+		t.Fatal("valid relative legacy engine should be resolved from config")
+		return enginebin.Resolved{}, nil
+	}
+	t.Cleanup(func() { resolveWSLPayloadFn = previousResolver })
+	previousInstall := runWSLCommandWithInputFn
+	runWSLCommandWithInputFn = func(context.Context, string, bool, string, string, string, ...string) (string, error) {
+		t.Fatal("plain init must not install or migrate a legacy WSL engine")
+		return "", nil
+	}
+	t.Cleanup(func() { runWSLCommandWithInputFn = previousInstall })
+
+	var out bytes.Buffer
+	if err := runInit(&out, workspace, "", []string{"local"}, false); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	if !strings.Contains(out.String(), "sqlrs init local --workspace") || !strings.Contains(out.String(), "--update") {
+		t.Fatalf("missing exact migration command: %q", out.String())
+	}
+	got, err := os.ReadFile(configPath)
+	if err != nil || !bytes.Equal(got, configData) {
+		t.Fatalf("plain init changed legacy config: err=%v\n%s", err, got)
+	}
+}
+
+func TestRemoveLegacyWSLEngineDaemonDuringExplicitUpdate(t *testing.T) {
+	marker := t.TempDir()
+	legacy := filepath.Join(marker, "legacy-linux-engine")
+	writeTestELF(t, legacy)
+	raw := map[string]any{
+		"orchestrator": map[string]any{"daemonPath": filepath.Base(legacy)},
+		"engine":       map[string]any{"wsl": map[string]any{"mode": "required"}},
+	}
+
+	removeLegacyWSLEngineDaemon(raw, filepath.Join(marker, "config.yaml"))
+	orchestrator := raw["orchestrator"].(map[string]any)
+	if _, exists := orchestrator["daemonPath"]; exists {
+		t.Fatal("validated legacy Linux daemonPath was not removed during explicit update")
+	}
+}
+
+func writeTestELF(t *testing.T, path string) {
+	t.Helper()
+	header := make([]byte, 64)
+	copy(header[:4], []byte("\x7fELF"))
+	header[4] = 2
+	header[5] = 1
+	machine := uint16(62)
+	if runtime.GOARCH == "arm64" {
+		machine = 183
+	}
+	binary.LittleEndian.PutUint16(header[18:20], machine)
+	if err := os.WriteFile(path, header, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/frontend/cli-go/internal/app/engine_discovery_regression_test.go
+++ b/frontend/cli-go/internal/app/engine_discovery_regression_test.go
@@ -33,6 +33,17 @@ var defaultTestHostResolver = func(req enginebin.Request) (enginebin.Resolved, e
 
 func TestMain(m *testing.M) {
 	resolveHostEngineFn = defaultTestHostResolver
+	resolveWSLPayloadFn = func(explicit string) (enginebin.Resolved, error) {
+		if strings.TrimSpace(explicit) != "" {
+			return (enginebin.Resolver{}).Resolve(enginebin.Request{
+				Kind:         enginebin.KindWSLPayload,
+				TargetOS:     "linux",
+				TargetArch:   runtime.GOARCH,
+				ExplicitPath: explicit,
+			})
+		}
+		return enginebin.Resolved{Path: filepath.Join(os.TempDir(), "sqlrs-engine-linux"), Kind: enginebin.KindWSLPayload, Origin: enginebin.OriginBundle}, nil
+	}
 	os.Exit(m.Run())
 }
 
@@ -62,7 +73,7 @@ func TestRunInitRejectsMissingHostEngineBeforeWritingConfig(t *testing.T) {
 	}
 }
 
-func TestResolveCommandContextValidatesConfiguredHostCandidate(t *testing.T) {
+func TestResolveCommandContextDefersConfiguredHostCandidateValidation(t *testing.T) {
 	temp := t.TempDir()
 	setTestDirs(t, temp)
 	marker := filepath.Join(temp, ".sqlrs")
@@ -75,15 +86,16 @@ func TestResolveCommandContextValidatesConfiguredHostCandidate(t *testing.T) {
 		t.Fatal(err)
 	}
 	withHostResolver(t, func(req enginebin.Request) (enginebin.Resolved, error) {
-		if req.ConfigPath != configured {
-			t.Fatalf("config candidate=%q, want %q", req.ConfigPath, configured)
-		}
-		return enginebin.Resolved{}, errors.New("format elf is incompatible with windows")
+		t.Fatal("command context must defer host discovery until daemon autostart")
+		return enginebin.Resolved{}, nil
 	})
 
-	_, err := resolveCommandContext(temp, cli.GlobalOptions{})
-	if err == nil || !strings.Contains(err.Error(), "resolve host engine") {
-		t.Fatalf("expected validated host-engine error, got %v", err)
+	ctx, err := resolveCommandContext(temp, cli.GlobalOptions{})
+	if err != nil {
+		t.Fatalf("resolveCommandContext: %v", err)
+	}
+	if ctx.daemonPath != configured {
+		t.Fatalf("daemonPath=%q, want deferred candidate %q", ctx.daemonPath, configured)
 	}
 }
 

--- a/frontend/cli-go/internal/app/init.go
+++ b/frontend/cli-go/internal/app/init.go
@@ -87,7 +87,9 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 	if err != nil {
 		return ExitErrorf(4, "Cannot create .sqlrs directory: %v", err)
 	}
+	explicitHostSource := ""
 	if opts.EnginePath != "" {
+		explicitHostSource = normalizeEngineSourcePath(opts.EnginePath, cwd)
 		opts.EnginePath = normalizeEnginePath(opts.EnginePath, cwd, target)
 	}
 	if opts.WSLEnginePath != "" {
@@ -128,10 +130,14 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 			}
 		}
 		if !opts.Update {
-			if configValid && !opts.DryRun && strings.EqualFold(opts.Mode, "local") {
+			if isWindows && configValid && !opts.DryRun && strings.EqualFold(opts.Mode, "local") {
 				repaired, repairErr := repairExistingWSLEngine(configPath, opts.WSLEnginePath, opts.Verbose)
 				if repairErr != nil {
-					return ExitErrorf(1, "WSL engine repair failed: %v", repairErr)
+					if errors.Is(repairErr, errLegacyWSLEngineUpdateRequired) {
+						fmt.Fprintf(w, "Legacy WSL engine configuration requires an explicit update. Run: sqlrs init local --workspace %q --update\n", target)
+					} else {
+						return ExitErrorf(1, "WSL engine repair failed: %v", repairErr)
+					}
 				}
 				if repaired {
 					fmt.Fprintln(w, "Repaired the provisioned WSL engine")
@@ -155,6 +161,7 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 	}
 
 	var wslResult *wslInitResult
+	usesWSLRuntime := false
 	if strings.EqualFold(opts.Mode, "local") {
 		snapshot := strings.ToLower(strings.TrimSpace(opts.Snapshot))
 		if snapshot == "" {
@@ -188,6 +195,7 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 				wslEngineSource = resolved.Path
 			}
 		}
+		usesWSLRuntime = useWSL
 		if useWSL && !opts.DryRun {
 			result, err := initWSLFn(wslInitOptions{
 				Enable:           true,
@@ -218,8 +226,26 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 					opts.WSLMode = "auto"
 				}
 			} else if snapshot == "auto" && !requireWSL {
+				usesWSLRuntime = false
 				resolvedStoreType = "dir"
 				resolvedStorePath, _ = resolveStorePath(resolvedStoreType, "")
+			}
+		}
+
+		if !usesWSLRuntime {
+			configuredHostPath, loadErr := configuredHostEngineForInit(target, configExists, configValid)
+			if loadErr != nil {
+				return ExitErrorf(64, "Invalid host engine configuration: %v", loadErr)
+			}
+			if _, resolveErr := resolveHostEngineFn(enginebin.Request{
+				Kind:            enginebin.KindHost,
+				TargetOS:        runtime.GOOS,
+				TargetArch:      runtime.GOARCH,
+				ExplicitPath:    explicitHostSource,
+				EnvironmentPath: os.Getenv("SQLRS_DAEMON_PATH"),
+				ConfigPath:      configuredHostPath,
+			}); resolveErr != nil {
+				return ExitErrorf(64, "Invalid host engine: %v", resolveErr)
 			}
 		}
 
@@ -268,6 +294,9 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 			return ExitErrorf(4, "Cannot read config.yaml: %v", err)
 		}
 		baseConfig = loaded
+		if wslResult != nil {
+			removeLegacyWSLEngineDaemon(baseConfig, configPath)
+		}
 	}
 	configData, err := buildWorkspaceConfig(opts, wslResult, baseConfig)
 	if err != nil {
@@ -285,6 +314,19 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 	return nil
 }
 
+func configuredHostEngineForInit(target string, configExists, configValid bool) (string, error) {
+	if configExists && !configValid {
+		return "", nil
+	}
+	loaded, err := config.Load(config.LoadOptions{WorkingDir: target})
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(loaded.Config.Orchestrator.DaemonPath), nil
+}
+
+var errLegacyWSLEngineUpdateRequired = errors.New("legacy WSL engine configuration requires --update")
+
 func repairExistingWSLEngine(configPath, explicitSource string, verbose bool) (bool, error) {
 	data, err := os.ReadFile(configPath)
 	if err != nil {
@@ -301,20 +343,13 @@ func repairExistingWSLEngine(configPath, explicitSource string, verbose bool) (b
 		return false, nil
 	}
 	if installed == "" {
-		resolved, resolveErr := resolveLegacyWSLEngineSource(cfg.Orchestrator.DaemonPath, explicitSource)
-		if resolveErr != nil {
+		legacyDaemonPath := resolveConfigRelativeEnginePath(cfg.Orchestrator.DaemonPath, configPath)
+		if _, resolveErr := resolveLegacyWSLEngineSource(legacyDaemonPath, explicitSource); resolveErr != nil {
 			return false, resolveErr
 		}
-		actual, installErr := installWSLEngine(context.Background(), distro, resolved.Path, "", verbose)
-		if installErr != nil {
-			return false, installErr
-		}
-		if err := migrateLegacyWSLEngineConfig(configPath, actual, resolved.Path == strings.TrimSpace(cfg.Orchestrator.DaemonPath)); err != nil {
-			return false, err
-		}
-		return true, nil
+		return false, errLegacyWSLEngineUpdateRequired
 	}
-	if _, err := runWSLCommandAllowFailureFn(context.Background(), distro, verbose, "check installed WSL engine", "test", "-x", installed); err == nil {
+	if err := validateInstalledWSLEngineFn(context.Background(), distro, installed, verbose); err == nil {
 		return false, nil
 	}
 	resolved, err := resolveWSLPayloadFn(explicitSource)
@@ -331,6 +366,46 @@ func repairExistingWSLEngine(configPath, explicitSource string, verbose bool) (b
 	return true, nil
 }
 
+func resolveConfigRelativeEnginePath(value, configPath string) string {
+	resolved := strings.TrimSpace(value)
+	if resolved == "" || filepath.IsAbs(resolved) {
+		return resolved
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(configPath), resolved))
+}
+
+func removeLegacyWSLEngineDaemon(raw map[string]any, configPath string) {
+	if nestedMapString(raw, "engine", "wsl", "enginePath") != "" {
+		return
+	}
+	orchestrator, ok := raw["orchestrator"].(map[string]any)
+	if !ok {
+		return
+	}
+	legacy, _ := orchestrator["daemonPath"].(string)
+	legacy = strings.TrimSpace(legacy)
+	if legacy == "" {
+		return
+	}
+	legacy = resolveConfigRelativeEnginePath(legacy, configPath)
+	if _, err := enginebin.Validate(legacy, "linux", runtime.GOARCH); err == nil {
+		delete(orchestrator, "daemonPath")
+	}
+}
+
+func nestedMapString(root map[string]any, keys ...string) string {
+	current := any(root)
+	for _, key := range keys {
+		next, ok := current.(map[string]any)
+		if !ok {
+			return ""
+		}
+		current = next[key]
+	}
+	value, _ := current.(string)
+	return strings.TrimSpace(value)
+}
+
 func resolveLegacyWSLEngineSource(legacyDaemonPath, explicitSource string) (enginebin.Resolved, error) {
 	if strings.TrimSpace(explicitSource) != "" {
 		return resolveWSLPayloadFn(explicitSource)
@@ -342,24 +417,6 @@ func resolveLegacyWSLEngineSource(legacyDaemonPath, explicitSource string) (engi
 		}
 	}
 	return resolveWSLPayloadFn("")
-}
-
-func migrateLegacyWSLEngineConfig(configPath, installedPath string, removeLegacyDaemon bool) error {
-	raw, err := readConfigMap(configPath)
-	if err != nil {
-		return err
-	}
-	setNested(raw, []string{"engine", "wsl", "enginePath"}, installedPath)
-	if removeLegacyDaemon {
-		if orchestrator, ok := raw["orchestrator"].(map[string]any); ok {
-			delete(orchestrator, "daemonPath")
-		}
-	}
-	data, err := yaml.Marshal(raw)
-	if err != nil {
-		return err
-	}
-	return util.AtomicWriteFile(configPath, data, 0o600)
 }
 
 func shouldRunStrictBtrfsInit(snapshot string, dryRun bool, wslResult *wslInitResult) bool {

--- a/frontend/cli-go/internal/app/init.go
+++ b/frontend/cli-go/internal/app/init.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -15,29 +16,31 @@ import (
 
 	"github.com/sqlrs/cli/internal/cli"
 	"github.com/sqlrs/cli/internal/config"
+	"github.com/sqlrs/cli/internal/enginebin"
 	"github.com/sqlrs/cli/internal/paths"
 	"github.com/sqlrs/cli/internal/util"
 )
 
 type initOptions struct {
-	Workspace   string
-	Force       bool
-	Update      bool
-	EnginePath  string
-	SharedCache bool
-	DryRun      bool
-	Snapshot    string
-	StoreType   string
-	StorePath   string
-	StoreSizeGB int
-	Reinit      bool
-	Distro      string
-	NoStart     bool
-	WSLMode     string
-	RemoteURL   string
-	RemoteToken string
-	Mode        string
-	Verbose     bool
+	Workspace     string
+	Force         bool
+	Update        bool
+	EnginePath    string
+	WSLEnginePath string
+	SharedCache   bool
+	DryRun        bool
+	Snapshot      string
+	StoreType     string
+	StorePath     string
+	StoreSizeGB   int
+	Reinit        bool
+	Distro        string
+	NoStart       bool
+	WSLMode       string
+	RemoteURL     string
+	RemoteToken   string
+	Mode          string
+	Verbose       bool
 }
 
 type localBtrfsInitOptions struct {
@@ -55,6 +58,16 @@ type localBtrfsInitResult struct {
 const defaultBtrfsStoreSizeGB = 100
 
 var initLocalBtrfsStoreFn = initLocalBtrfsStore
+
+var resolveWSLPayloadFn = func(explicit string) (enginebin.Resolved, error) {
+	return (enginebin.Resolver{}).Resolve(enginebin.Request{
+		Kind:            enginebin.KindWSLPayload,
+		TargetOS:        "linux",
+		TargetArch:      runtime.GOARCH,
+		ExplicitPath:    explicit,
+		EnvironmentPath: os.Getenv("SQLRS_WSL_ENGINE_PATH"),
+	})
+}
 
 func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bool) error {
 	opts, showHelp, err := parseInitFlags(args, globalWorkspace)
@@ -74,6 +87,12 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 	if err != nil {
 		return ExitErrorf(4, "Cannot create .sqlrs directory: %v", err)
 	}
+	if opts.EnginePath != "" {
+		opts.EnginePath = normalizeEnginePath(opts.EnginePath, cwd, target)
+	}
+	if opts.WSLEnginePath != "" {
+		opts.WSLEnginePath = normalizeEngineSourcePath(opts.WSLEnginePath, cwd)
+	}
 
 	localMarker := filepath.Join(target, ".sqlrs")
 	localExists := dirExists(localMarker)
@@ -85,6 +104,7 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 
 	configPath := filepath.Join(localMarker, "config.yaml")
 	hasUpdateFlags := opts.EnginePath != "" ||
+		opts.WSLEnginePath != "" ||
 		opts.SharedCache ||
 		opts.Snapshot != "" ||
 		opts.StoreType != "" ||
@@ -108,6 +128,15 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 			}
 		}
 		if !opts.Update {
+			if configValid && !opts.DryRun && strings.EqualFold(opts.Mode, "local") {
+				repaired, repairErr := repairExistingWSLEngine(configPath, opts.WSLEnginePath, opts.Verbose)
+				if repairErr != nil {
+					return ExitErrorf(1, "WSL engine repair failed: %v", repairErr)
+				}
+				if repaired {
+					fmt.Fprintln(w, "Repaired the provisioned WSL engine")
+				}
+			}
 			if opts.DryRun {
 				fmt.Fprintf(w, "Workspace already initialized at %s (dry-run)\n", target)
 			} else {
@@ -123,10 +152,6 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 			}
 			return nil
 		}
-	}
-
-	if opts.EnginePath != "" {
-		opts.EnginePath = normalizeEnginePath(opts.EnginePath, cwd, target)
 	}
 
 	var wslResult *wslInitResult
@@ -148,22 +173,33 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 
 		storeExplicit := opts.StoreType != "" || opts.StorePath != ""
 		useWSL, requireWSL := shouldUseWSL(snapshot, resolvedStoreType, storeExplicit)
+		var wslEngineSource string
 		if useWSL {
-			if err := validateLinuxEngineBinaryForWSL(opts.EnginePath); err != nil {
-				return ExitErrorf(64, "Invalid arguments: %v", err)
+			resolved, resolveErr := resolveWSLPayloadFn(opts.WSLEnginePath)
+			if resolveErr != nil {
+				explicitWSLEngine := strings.TrimSpace(opts.WSLEnginePath) != "" || strings.TrimSpace(os.Getenv("SQLRS_WSL_ENGINE_PATH")) != ""
+				if requireWSL || explicitWSLEngine {
+					return ExitErrorf(64, "Invalid WSL engine: %v", resolveErr)
+				}
+				useWSL = false
+				resolvedStoreType = "dir"
+				resolvedStorePath, _ = resolveStorePath(resolvedStoreType, "")
+			} else {
+				wslEngineSource = resolved.Path
 			}
 		}
 		if useWSL && !opts.DryRun {
 			result, err := initWSLFn(wslInitOptions{
-				Enable:      true,
-				Distro:      opts.Distro,
-				Require:     requireWSL,
-				NoStart:     opts.NoStart,
-				Workspace:   target,
-				Verbose:     opts.Verbose,
-				StoreSizeGB: opts.StoreSizeGB,
-				Reinit:      opts.Reinit,
-				StorePath:   resolvedStorePath,
+				Enable:           true,
+				Distro:           opts.Distro,
+				Require:          requireWSL,
+				NoStart:          opts.NoStart,
+				Workspace:        target,
+				Verbose:          opts.Verbose,
+				StoreSizeGB:      opts.StoreSizeGB,
+				Reinit:           opts.Reinit,
+				StorePath:        resolvedStorePath,
+				EngineSourcePath: wslEngineSource,
 			})
 			if err != nil {
 				return ExitErrorf(1, "WSL init failed: %v", err)
@@ -249,6 +285,83 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 	return nil
 }
 
+func repairExistingWSLEngine(configPath, explicitSource string, verbose bool) (bool, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return false, err
+	}
+	var cfg config.Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return false, err
+	}
+	mode := strings.ToLower(strings.TrimSpace(cfg.Engine.WSL.Mode))
+	distro := strings.TrimSpace(cfg.Engine.WSL.Distro)
+	installed := strings.TrimSpace(cfg.Engine.WSL.EnginePath)
+	if (mode != "auto" && mode != "required") || distro == "" {
+		return false, nil
+	}
+	if installed == "" {
+		resolved, resolveErr := resolveLegacyWSLEngineSource(cfg.Orchestrator.DaemonPath, explicitSource)
+		if resolveErr != nil {
+			return false, resolveErr
+		}
+		actual, installErr := installWSLEngine(context.Background(), distro, resolved.Path, "", verbose)
+		if installErr != nil {
+			return false, installErr
+		}
+		if err := migrateLegacyWSLEngineConfig(configPath, actual, resolved.Path == strings.TrimSpace(cfg.Orchestrator.DaemonPath)); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+	if _, err := runWSLCommandAllowFailureFn(context.Background(), distro, verbose, "check installed WSL engine", "test", "-x", installed); err == nil {
+		return false, nil
+	}
+	resolved, err := resolveWSLPayloadFn(explicitSource)
+	if err != nil {
+		return false, err
+	}
+	actual, err := installWSLEngine(context.Background(), distro, resolved.Path, installed, verbose)
+	if err != nil {
+		return false, err
+	}
+	if actual != installed {
+		return false, fmt.Errorf("installer returned %q, expected configured path %q", actual, installed)
+	}
+	return true, nil
+}
+
+func resolveLegacyWSLEngineSource(legacyDaemonPath, explicitSource string) (enginebin.Resolved, error) {
+	if strings.TrimSpace(explicitSource) != "" {
+		return resolveWSLPayloadFn(explicitSource)
+	}
+	legacy := strings.TrimSpace(legacyDaemonPath)
+	if legacy != "" {
+		if validation, err := enginebin.Validate(legacy, "linux", runtime.GOARCH); err == nil {
+			return enginebin.Resolved{Path: legacy, Kind: enginebin.KindWSLPayload, Origin: enginebin.OriginConfig, Format: validation.Format, Arch: validation.Arch}, nil
+		}
+	}
+	return resolveWSLPayloadFn("")
+}
+
+func migrateLegacyWSLEngineConfig(configPath, installedPath string, removeLegacyDaemon bool) error {
+	raw, err := readConfigMap(configPath)
+	if err != nil {
+		return err
+	}
+	setNested(raw, []string{"engine", "wsl", "enginePath"}, installedPath)
+	if removeLegacyDaemon {
+		if orchestrator, ok := raw["orchestrator"].(map[string]any); ok {
+			delete(orchestrator, "daemonPath")
+		}
+	}
+	data, err := yaml.Marshal(raw)
+	if err != nil {
+		return err
+	}
+	return util.AtomicWriteFile(configPath, data, 0o600)
+}
+
 func shouldRunStrictBtrfsInit(snapshot string, dryRun bool, wslResult *wslInitResult) bool {
 	return strings.EqualFold(strings.TrimSpace(snapshot), "btrfs") && !dryRun && wslResult == nil
 }
@@ -322,6 +435,7 @@ func parseInitFlags(args []string, globalWorkspace string) (initOptions, bool, e
 	workspace := fs.String("workspace", "", "workspace root")
 	force := fs.Bool("force", false, "allow nested workspace")
 	engine := fs.String("engine", "", "engine binary path")
+	wslEngine := fs.String("wsl-engine", "", "Linux engine binary to install into WSL")
 	sharedCache := fs.Bool("shared-cache", false, "use shared cache")
 	update := fs.Bool("update", false, "update existing workspace config")
 	snapshot := fs.String("snapshot", "", "snapshot backend")
@@ -357,6 +471,7 @@ func parseInitFlags(args []string, globalWorkspace string) (initOptions, bool, e
 	opts.Force = *force
 	opts.Update = *update
 	opts.EnginePath = strings.TrimSpace(*engine)
+	opts.WSLEnginePath = strings.TrimSpace(*wslEngine)
 	opts.SharedCache = *sharedCache
 	opts.DryRun = *dryRun
 	opts.Snapshot = normalizeSnapshot(*snapshot)
@@ -389,7 +504,7 @@ func parseInitFlags(args []string, globalWorkspace string) (initOptions, bool, e
 		if opts.RemoteURL == "" || opts.RemoteToken == "" {
 			return opts, false, ExitErrorf(64, "Invalid arguments: --url and --token are required for remote init")
 		}
-		if opts.EnginePath != "" || opts.SharedCache || opts.Snapshot != "" || opts.StoreType != "" || opts.StorePath != "" || opts.StoreSizeGB > 0 || opts.Reinit || opts.Distro != "" || opts.NoStart {
+		if opts.EnginePath != "" || opts.WSLEnginePath != "" || opts.SharedCache || opts.Snapshot != "" || opts.StoreType != "" || opts.StorePath != "" || opts.StoreSizeGB > 0 || opts.Reinit || opts.Distro != "" || opts.NoStart {
 			return opts, false, ExitErrorf(64, "Invalid arguments: local-only flags are not valid for remote init")
 		}
 		return opts, false, nil
@@ -574,6 +689,21 @@ func normalizeEnginePath(enginePath, cwd, workspace string) string {
 	}
 
 	return filepath.Clean(filepath.Join(cwdAbs, path))
+}
+
+func normalizeEngineSourcePath(enginePath, cwd string) string {
+	value := strings.TrimSpace(enginePath)
+	if value == "" {
+		return ""
+	}
+	if filepath.IsAbs(value) {
+		return filepath.Clean(value)
+	}
+	base := strings.TrimSpace(cwd)
+	if base == "" {
+		base, _ = os.Getwd()
+	}
+	return filepath.Clean(filepath.Join(base, value))
 }
 
 func resolveExistingPath(value string) string {

--- a/frontend/cli-go/internal/app/init.go
+++ b/frontend/cli-go/internal/app/init.go
@@ -553,7 +553,6 @@ func parseInitFlags(args []string, globalWorkspace string) (initOptions, bool, e
 	if mode != "local" && mode != "remote" {
 		return opts, false, ExitErrorf(64, "Invalid arguments: unknown init mode")
 	}
-
 	if mode == "remote" {
 		if opts.RemoteURL == "" || opts.RemoteToken == "" {
 			return opts, false, ExitErrorf(64, "Invalid arguments: --url and --token are required for remote init")
@@ -562,6 +561,9 @@ func parseInitFlags(args []string, globalWorkspace string) (initOptions, bool, e
 			return opts, false, ExitErrorf(64, "Invalid arguments: local-only flags are not valid for remote init")
 		}
 		return opts, false, nil
+	}
+	if opts.WSLEnginePath != "" && !isWindows {
+		return opts, false, ExitErrorf(64, "Invalid arguments: --wsl-engine is only valid on Windows")
 	}
 
 	if opts.RemoteURL != "" || opts.RemoteToken != "" {

--- a/frontend/cli-go/internal/app/init.go
+++ b/frontend/cli-go/internal/app/init.go
@@ -59,6 +59,10 @@ const defaultBtrfsStoreSizeGB = 100
 
 var initLocalBtrfsStoreFn = initLocalBtrfsStore
 
+var resolveHostEngineFn = func(req enginebin.Request) (enginebin.Resolved, error) {
+	return (enginebin.Resolver{}).Resolve(req)
+}
+
 var resolveWSLPayloadFn = func(explicit string) (enginebin.Resolved, error) {
 	return (enginebin.Resolver{}).Resolve(enginebin.Request{
 		Kind:            enginebin.KindWSLPayload,
@@ -184,16 +188,9 @@ func runInit(w io.Writer, cwd, globalWorkspace string, args []string, verbose bo
 		if useWSL {
 			resolved, resolveErr := resolveWSLPayloadFn(opts.WSLEnginePath)
 			if resolveErr != nil {
-				explicitWSLEngine := strings.TrimSpace(opts.WSLEnginePath) != "" || strings.TrimSpace(os.Getenv("SQLRS_WSL_ENGINE_PATH")) != ""
-				if requireWSL || explicitWSLEngine {
-					return ExitErrorf(64, "Invalid WSL engine: %v", resolveErr)
-				}
-				useWSL = false
-				resolvedStoreType = "dir"
-				resolvedStorePath, _ = resolveStorePath(resolvedStoreType, "")
-			} else {
-				wslEngineSource = resolved.Path
+				return ExitErrorf(64, "Invalid WSL engine: %v", resolveErr)
 			}
+			wslEngineSource = resolved.Path
 		}
 		usesWSLRuntime = useWSL
 		if useWSL && !opts.DryRun {

--- a/frontend/cli-go/internal/app/init_engine_discovery_test.go
+++ b/frontend/cli-go/internal/app/init_engine_discovery_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -66,6 +67,9 @@ func TestInstallWSLEngineWritesAtomically(t *testing.T) {
 }
 
 func TestRunInitPassesResolvedWSLEngineToProvisioner(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("WSL init is only exercised by the Windows CI job")
+	}
 	withWindowsMode(t)
 	workspace := t.TempDir()
 	engine := filepath.Join(workspace, "sqlrs-engine")

--- a/frontend/cli-go/internal/app/init_engine_discovery_test.go
+++ b/frontend/cli-go/internal/app/init_engine_discovery_test.go
@@ -129,8 +129,8 @@ func TestRunInitRepairsMissingDerivedWSLEngineWithoutUpdate(t *testing.T) {
 	installedCalls := 0
 	runWSLCommandWithInputFn = func(_ context.Context, _ string, _ bool, _ string, _ string, _ string, args ...string) (string, error) {
 		installedCalls++
-		if args[len(args)-1] != installed {
-			t.Fatalf("repair destination=%q", args[len(args)-1])
+		if args[len(args)-2] != installed {
+			t.Fatalf("repair destination=%q", args[len(args)-2])
 		}
 		return installed + "\n", nil
 	}

--- a/frontend/cli-go/internal/app/init_engine_discovery_test.go
+++ b/frontend/cli-go/internal/app/init_engine_discovery_test.go
@@ -13,12 +13,24 @@ import (
 )
 
 func TestParseInitFlagsSeparatesHostAndWSLEngines(t *testing.T) {
+	withWindowsMode(t)
 	opts, help, err := parseInitFlags([]string{"local", "--engine", "host.exe", "--wsl-engine", "linux-engine"}, "")
 	if err != nil || help {
 		t.Fatalf("parseInitFlags() help=%v err=%v", help, err)
 	}
 	if opts.EnginePath != "host.exe" || opts.WSLEnginePath != "linux-engine" {
 		t.Fatalf("unexpected engine paths: host=%q wsl=%q", opts.EnginePath, opts.WSLEnginePath)
+	}
+}
+
+func TestParseInitFlagsRejectsWSLEngineOutsideWindows(t *testing.T) {
+	previous := isWindows
+	isWindows = false
+	t.Cleanup(func() { isWindows = previous })
+
+	_, _, err := parseInitFlags([]string{"local", "--wsl-engine", "linux-engine"}, "")
+	if err == nil || !strings.Contains(err.Error(), "only valid on Windows") {
+		t.Fatalf("expected Windows-only flag error, got %v", err)
 	}
 }
 

--- a/frontend/cli-go/internal/app/init_engine_discovery_test.go
+++ b/frontend/cli-go/internal/app/init_engine_discovery_test.go
@@ -1,0 +1,166 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sqlrs/cli/internal/enginebin"
+)
+
+func TestParseInitFlagsSeparatesHostAndWSLEngines(t *testing.T) {
+	opts, help, err := parseInitFlags([]string{"local", "--engine", "host.exe", "--wsl-engine", "linux-engine"}, "")
+	if err != nil || help {
+		t.Fatalf("parseInitFlags() help=%v err=%v", help, err)
+	}
+	if opts.EnginePath != "host.exe" || opts.WSLEnginePath != "linux-engine" {
+		t.Fatalf("unexpected engine paths: host=%q wsl=%q", opts.EnginePath, opts.WSLEnginePath)
+	}
+}
+
+func TestParseInitFlagsRejectsWSLEngineForRemote(t *testing.T) {
+	_, _, err := parseInitFlags([]string{"remote", "--url", "https://example.test", "--token", "secret", "--wsl-engine", "linux-engine"}, "")
+	if err == nil || !strings.Contains(err.Error(), "local-only") {
+		t.Fatalf("expected local-only flag error, got %v", err)
+	}
+}
+
+func TestInstallWSLEngineWritesAtomically(t *testing.T) {
+	source := filepath.Join(t.TempDir(), "sqlrs-engine")
+	payload := []byte("\x7fELF-linux-engine")
+	if err := os.WriteFile(source, payload, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	previous := runWSLCommandWithInputFn
+	t.Cleanup(func() { runWSLCommandWithInputFn = previous })
+	var gotInput, gotCommand string
+	var gotArgs []string
+	runWSLCommandWithInputFn = func(_ context.Context, distro string, verbose bool, desc, input, command string, args ...string) (string, error) {
+		if distro != "Ubuntu" || desc != "install WSL engine" {
+			t.Fatalf("unexpected call distro=%q desc=%q", distro, desc)
+		}
+		gotInput, gotCommand, gotArgs = input, command, append([]string(nil), args...)
+		return defaultInstalledWSLEnginePath + "\n", nil
+	}
+
+	got, err := installWSLEngine(context.Background(), "Ubuntu", source, "", false)
+	if err != nil {
+		t.Fatalf("installWSLEngine: %v", err)
+	}
+	if got != defaultInstalledWSLEnginePath {
+		t.Fatalf("installed path=%q", got)
+	}
+	if !bytes.Equal([]byte(gotInput), payload) {
+		t.Fatal("installer did not stream the source payload")
+	}
+	joined := gotCommand + " " + strings.Join(gotArgs, " ")
+	for _, required := range []string{"mktemp", "chmod 755", "mv -f", "$HOME/.local/lib/sqlrs/sqlrs-engine"} {
+		if !strings.Contains(joined, required) {
+			t.Fatalf("atomic install command %q does not contain %q", joined, required)
+		}
+	}
+}
+
+func TestRunInitPassesResolvedWSLEngineToProvisioner(t *testing.T) {
+	withWindowsMode(t)
+	workspace := t.TempDir()
+	engine := filepath.Join(workspace, "sqlrs-engine")
+	if err := os.WriteFile(engine, []byte("engine"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	withInitWSLStub(t, func(opts wslInitOptions) (wslInitResult, error) {
+		if opts.EngineSourcePath != engine {
+			t.Fatalf("engine source=%q, want %q", opts.EngineSourcePath, engine)
+		}
+		return wslInitResult{UseWSL: true, EnginePath: defaultInstalledWSLEnginePath}, nil
+	})
+	previousResolver := resolveWSLPayloadFn
+	resolveWSLPayloadFn = func(explicit string) (enginebin.Resolved, error) {
+		if explicit != engine {
+			t.Fatalf("explicit WSL engine=%q", explicit)
+		}
+		return enginebin.Resolved{Path: engine, Kind: enginebin.KindWSLPayload}, nil
+	}
+	t.Cleanup(func() { resolveWSLPayloadFn = previousResolver })
+
+	var out bytes.Buffer
+	if err := runInit(&out, workspace, "", []string{"local", "--snapshot", "btrfs", "--wsl-engine", "sqlrs-engine"}, false); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+}
+
+func TestRunInitRepairsMissingDerivedWSLEngineWithoutUpdate(t *testing.T) {
+	withWindowsMode(t)
+	workspace := t.TempDir()
+	marker := filepath.Join(workspace, ".sqlrs")
+	if err := os.MkdirAll(marker, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	const installed = "/home/user/.local/lib/sqlrs/sqlrs-engine"
+	configData := []byte("engine:\n  wsl:\n    mode: required\n    distro: Ubuntu\n    enginePath: " + installed + "\n")
+	if err := os.WriteFile(filepath.Join(marker, "config.yaml"), configData, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	source := filepath.Join(t.TempDir(), "sqlrs-engine")
+	if err := os.WriteFile(source, []byte("payload"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	previousResolver := resolveWSLPayloadFn
+	resolveWSLPayloadFn = func(string) (enginebin.Resolved, error) {
+		return enginebin.Resolved{Path: source, Kind: enginebin.KindWSLPayload}, nil
+	}
+	t.Cleanup(func() { resolveWSLPayloadFn = previousResolver })
+	previousCheck := runWSLCommandAllowFailureFn
+	runWSLCommandAllowFailureFn = func(context.Context, string, bool, string, string, ...string) (string, error) {
+		return "", os.ErrNotExist
+	}
+	t.Cleanup(func() { runWSLCommandAllowFailureFn = previousCheck })
+	previousInstall := runWSLCommandWithInputFn
+	installedCalls := 0
+	runWSLCommandWithInputFn = func(_ context.Context, _ string, _ bool, _ string, _ string, _ string, args ...string) (string, error) {
+		installedCalls++
+		if args[len(args)-1] != installed {
+			t.Fatalf("repair destination=%q", args[len(args)-1])
+		}
+		return installed + "\n", nil
+	}
+	t.Cleanup(func() { runWSLCommandWithInputFn = previousInstall })
+
+	var out bytes.Buffer
+	if err := runInit(&out, workspace, "", []string{"local"}, false); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	if installedCalls != 1 {
+		t.Fatalf("install calls=%d", installedCalls)
+	}
+	got, err := os.ReadFile(filepath.Join(marker, "config.yaml"))
+	if err != nil || !bytes.Equal(got, configData) {
+		t.Fatalf("repair changed workspace config: err=%v\n%s", err, got)
+	}
+}
+
+func TestRunInitAutoFallsBackToDirectoryWhenWSLPayloadIsUnavailable(t *testing.T) {
+	withWindowsMode(t)
+	previousResolver := resolveWSLPayloadFn
+	resolveWSLPayloadFn = func(string) (enginebin.Resolved, error) {
+		return enginebin.Resolved{}, os.ErrNotExist
+	}
+	t.Cleanup(func() { resolveWSLPayloadFn = previousResolver })
+	storeRoot := filepath.Join(t.TempDir(), "store")
+	t.Setenv("SQLRS_STATE_STORE", storeRoot)
+	workspace := t.TempDir()
+	var out bytes.Buffer
+	if err := runInit(&out, workspace, "", []string{"local"}, false); err != nil {
+		t.Fatalf("runInit: %v", err)
+	}
+	raw := loadConfigMap(t, filepath.Join(workspace, ".sqlrs", "config.yaml"))
+	if got := nestedString(raw, "engine", "storePath"); got != storeRoot {
+		t.Fatalf("storePath=%q, want directory fallback %q", got, storeRoot)
+	}
+}

--- a/frontend/cli-go/internal/app/init_engine_discovery_test.go
+++ b/frontend/cli-go/internal/app/init_engine_discovery_test.go
@@ -150,6 +150,9 @@ func TestRunInitRepairsMissingDerivedWSLEngineWithoutUpdate(t *testing.T) {
 }
 
 func TestRunInitAutoRejectsUnavailableWSLPayload(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("automatic WSL selection is only available on Windows")
+	}
 	withWindowsMode(t)
 	previousResolver := resolveWSLPayloadFn
 	resolveWSLPayloadFn = func(string) (enginebin.Resolved, error) {

--- a/frontend/cli-go/internal/app/init_engine_discovery_test.go
+++ b/frontend/cli-go/internal/app/init_engine_discovery_test.go
@@ -149,22 +149,20 @@ func TestRunInitRepairsMissingDerivedWSLEngineWithoutUpdate(t *testing.T) {
 	}
 }
 
-func TestRunInitAutoFallsBackToDirectoryWhenWSLPayloadIsUnavailable(t *testing.T) {
+func TestRunInitAutoRejectsUnavailableWSLPayload(t *testing.T) {
 	withWindowsMode(t)
 	previousResolver := resolveWSLPayloadFn
 	resolveWSLPayloadFn = func(string) (enginebin.Resolved, error) {
 		return enginebin.Resolved{}, os.ErrNotExist
 	}
 	t.Cleanup(func() { resolveWSLPayloadFn = previousResolver })
-	storeRoot := filepath.Join(t.TempDir(), "store")
-	t.Setenv("SQLRS_STATE_STORE", storeRoot)
 	workspace := t.TempDir()
 	var out bytes.Buffer
-	if err := runInit(&out, workspace, "", []string{"local"}, false); err != nil {
-		t.Fatalf("runInit: %v", err)
+	err := runInit(&out, workspace, "", []string{"local"}, false)
+	if err == nil || !strings.Contains(err.Error(), "Invalid WSL engine") {
+		t.Fatalf("expected missing-payload error, got %v", err)
 	}
-	raw := loadConfigMap(t, filepath.Join(workspace, ".sqlrs", "config.yaml"))
-	if got := nestedString(raw, "engine", "storePath"); got != storeRoot {
-		t.Fatalf("storePath=%q, want directory fallback %q", got, storeRoot)
+	if _, statErr := os.Stat(filepath.Join(workspace, ".sqlrs")); !os.IsNotExist(statErr) {
+		t.Fatalf("workspace marker must not be written, stat err=%v", statErr)
 	}
 }

--- a/frontend/cli-go/internal/app/init_more_coverage_test.go
+++ b/frontend/cli-go/internal/app/init_more_coverage_test.go
@@ -82,19 +82,17 @@ func TestRunInitWSLAutoModeBranchCoverage(t *testing.T) {
 		t.Skip("windows-only path")
 	}
 
-	prevWSL := initWSLFn
-	initWSLFn = func(opts wslInitOptions) (wslInitResult, error) {
+	withInitWSLStub(t, func(opts wslInitOptions) (wslInitResult, error) {
 		return wslInitResult{
 			UseWSL:      true,
 			Distro:      "Ubuntu",
 			StateDir:    "/mnt/sqlrs/store",
-			EnginePath:  "/mnt/c/sqlrs/sqlrs-engine.exe",
+			EnginePath:  "/home/user/.local/lib/sqlrs/sqlrs-engine",
 			StorePath:   "C:\\sqlrs\\store\\btrfs.vhdx",
 			MountUnit:   "sqlrs.mount",
 			MountFSType: "btrfs",
 		}, nil
-	}
-	t.Cleanup(func() { initWSLFn = prevWSL })
+	})
 
 	workspace := t.TempDir()
 	var out bytes.Buffer

--- a/frontend/cli-go/internal/app/init_windows_test.go
+++ b/frontend/cli-go/internal/app/init_windows_test.go
@@ -79,7 +79,7 @@ func TestInitRejectsWindowsEngineBinaryForWSL(t *testing.T) {
 	err := runInit(&out, workspace, "", []string{
 		"local",
 		"--snapshot", "btrfs",
-		"--engine", enginePath,
+		"--wsl-engine", enginePath,
 	}, false)
 	var exitErr *ExitError
 	if !errors.As(err, &exitErr) {
@@ -88,7 +88,7 @@ func TestInitRejectsWindowsEngineBinaryForWSL(t *testing.T) {
 	if exitErr.Code != 64 {
 		t.Fatalf("expected exit code 64, got %d", exitErr.Code)
 	}
-	if !strings.Contains(err.Error(), "Linux sqlrs-engine binary") {
+	if !strings.Contains(err.Error(), "Invalid WSL engine") {
 		t.Fatalf("unexpected error message: %q", err.Error())
 	}
 }
@@ -108,7 +108,7 @@ func TestInitAcceptsLinuxEngineBinaryForWSL(t *testing.T) {
 	if err := runInit(&out, workspace, "", []string{
 		"local",
 		"--snapshot", "btrfs",
-		"--engine", enginePath,
+		"--wsl-engine", enginePath,
 	}, false); err != nil {
 		t.Fatalf("runInit: %v", err)
 	}

--- a/frontend/cli-go/internal/app/init_wsl.go
+++ b/frontend/cli-go/internal/app/init_wsl.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"strings"
@@ -12,15 +13,16 @@ import (
 )
 
 type wslInitOptions struct {
-	Enable      bool
-	Distro      string
-	Require     bool
-	NoStart     bool
-	Workspace   string
-	Verbose     bool
-	StoreSizeGB int
-	Reinit      bool
-	StorePath   string
+	Enable           bool
+	Distro           string
+	Require          bool
+	NoStart          bool
+	Workspace        string
+	Verbose          bool
+	StoreSizeGB      int
+	Reinit           bool
+	StorePath        string
+	EngineSourcePath string
 }
 
 type wslInitResult struct {
@@ -71,6 +73,7 @@ var isTerminalWriterFn = isTerminalWriter
 var isWindows = runtime.GOOS == "windows"
 
 const defaultVHDXName = "btrfs.vhdx"
+const defaultInstalledWSLEnginePath = "/home/user/.local/lib/sqlrs/sqlrs-engine"
 
 func defaultWSLInitDeps() wslInitDeps {
 	return wslInitDeps{
@@ -95,6 +98,14 @@ func initWSL(opts wslInitOptions) (wslInitResult, error) {
 		return wslUnavailable(opts, err.Error())
 	}
 
+	enginePath := ""
+	if strings.TrimSpace(opts.EngineSourcePath) != "" {
+		enginePath, err = installWSLEngine(context.Background(), bootstrap.Distro, opts.EngineSourcePath, "", opts.Verbose)
+		if err != nil {
+			return wslUnavailable(opts, err.Error())
+		}
+	}
+
 	storage, err := prepareWSLStorage(context.Background(), deps, opts, bootstrap.Distro)
 	if err != nil {
 		return wslUnavailable(opts, err.Error())
@@ -112,6 +123,7 @@ func initWSL(opts wslInitOptions) (wslInitResult, error) {
 	return wslInitResult{
 		UseWSL:          true,
 		Distro:          bootstrap.Distro,
+		EnginePath:      enginePath,
 		StateDir:        storage.StateDir,
 		StorePath:       storage.StorePath,
 		MountDevice:     storage.Partition,
@@ -120,6 +132,34 @@ func initWSL(opts wslInitOptions) (wslInitResult, error) {
 		MountDeviceUUID: mount.DeviceUUID,
 		Warning:         strings.Join(warnings, "\n"),
 	}, nil
+}
+
+func installWSLEngine(ctx context.Context, distro, sourcePath, destination string, verbose bool) (string, error) {
+	payload, err := os.ReadFile(sourcePath)
+	if err != nil {
+		return "", fmt.Errorf("read WSL engine payload: %w", err)
+	}
+	const script = `set -eu
+dest="$1"
+if [ -z "$dest" ]; then dest="$HOME/.local/lib/sqlrs/sqlrs-engine"; fi
+dir="${dest%/*}"
+mkdir -p "$dir"
+tmp="$(mktemp "$dir/.sqlrs-engine.XXXXXX")"
+trap 'rm -f "$tmp"' EXIT
+cat >"$tmp"
+chmod 755 "$tmp"
+mv -f "$tmp" "$dest"
+trap - EXIT
+printf '%s\n' "$dest"`
+	out, err := runWSLCommandWithInputFn(ctx, distro, verbose, "install WSL engine", string(payload), "sh", "-c", script, "sqlrs-engine-installer", strings.TrimSpace(destination))
+	if err != nil {
+		return "", fmt.Errorf("install WSL engine: %w", err)
+	}
+	installed := strings.TrimSpace(out)
+	if installed == "" || !strings.HasPrefix(installed, "/") {
+		return "", fmt.Errorf("install WSL engine: installer returned invalid path %q", installed)
+	}
+	return installed, nil
 }
 
 func wslUnavailable(opts wslInitOptions, warning string) (wslInitResult, error) {

--- a/frontend/cli-go/internal/app/init_wsl.go
+++ b/frontend/cli-go/internal/app/init_wsl.go
@@ -71,6 +71,7 @@ var runHostCommandFn = runHostCommand
 var isElevatedFn = isElevated
 var isTerminalWriterFn = isTerminalWriter
 var isWindows = runtime.GOOS == "windows"
+var validateInstalledWSLEngineFn = validateInstalledWSLEngine
 
 const defaultVHDXName = "btrfs.vhdx"
 const defaultInstalledWSLEnginePath = "/home/user/.local/lib/sqlrs/sqlrs-engine"
@@ -139,19 +140,28 @@ func installWSLEngine(ctx context.Context, distro, sourcePath, destination strin
 	if err != nil {
 		return "", fmt.Errorf("read WSL engine payload: %w", err)
 	}
+	expectedMachine, err := expectedELFMachineHex(runtime.GOARCH)
+	if err != nil {
+		return "", err
+	}
 	const script = `set -eu
 dest="$1"
+expected_machine="$2"
 if [ -z "$dest" ]; then dest="$HOME/.local/lib/sqlrs/sqlrs-engine"; fi
 dir="${dest%/*}"
 mkdir -p "$dir"
 tmp="$(mktemp "$dir/.sqlrs-engine.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
 cat >"$tmp"
+magic="$(dd if="$tmp" bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+machine="$(dd if="$tmp" bs=1 skip=18 count=2 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+test "$magic" = "7f454c46"
+test "$machine" = "$expected_machine"
 chmod 755 "$tmp"
 mv -f "$tmp" "$dest"
 trap - EXIT
 printf '%s\n' "$dest"`
-	out, err := runWSLCommandWithInputFn(ctx, distro, verbose, "install WSL engine", string(payload), "sh", "-c", script, "sqlrs-engine-installer", strings.TrimSpace(destination))
+	out, err := runWSLCommandWithInputFn(ctx, distro, verbose, "install WSL engine", string(payload), "sh", "-c", script, "sqlrs-engine-installer", strings.TrimSpace(destination), expectedMachine)
 	if err != nil {
 		return "", fmt.Errorf("install WSL engine: %w", err)
 	}
@@ -160,6 +170,37 @@ printf '%s\n' "$dest"`
 		return "", fmt.Errorf("install WSL engine: installer returned invalid path %q", installed)
 	}
 	return installed, nil
+}
+
+func validateInstalledWSLEngine(ctx context.Context, distro, installedPath string, verbose bool) error {
+	expectedMachine, err := expectedELFMachineHex(runtime.GOARCH)
+	if err != nil {
+		return err
+	}
+	const script = `set -eu
+path="$1"
+expected_machine="$2"
+test -f "$path"
+test -x "$path"
+magic="$(dd if="$path" bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+machine="$(dd if="$path" bs=1 skip=18 count=2 2>/dev/null | od -An -tx1 | tr -d ' \n')"
+test "$magic" = "7f454c46"
+test "$machine" = "$expected_machine"`
+	if _, err := runWSLCommandAllowFailureFn(ctx, distro, verbose, "validate installed WSL engine", "sh", "-c", script, "sqlrs-engine-validator", strings.TrimSpace(installedPath), expectedMachine); err != nil {
+		return fmt.Errorf("installed WSL engine is missing or incompatible: %w", err)
+	}
+	return nil
+}
+
+func expectedELFMachineHex(goarch string) (string, error) {
+	switch goarch {
+	case "amd64":
+		return "3e00", nil
+	case "arm64":
+		return "b700", nil
+	default:
+		return "", fmt.Errorf("unsupported WSL engine architecture %q", goarch)
+	}
 }
 
 func wslUnavailable(opts wslInitOptions, warning string) (wslInitResult, error) {

--- a/frontend/cli-go/internal/app/init_wsl_test.go
+++ b/frontend/cli-go/internal/app/init_wsl_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sqlrs/cli/internal/enginebin"
 	"gopkg.in/yaml.v3"
 )
 
@@ -211,8 +212,13 @@ func withInitWSLStub(t *testing.T, fn func(opts wslInitOptions) (wslInitResult, 
 	t.Helper()
 	prev := initWSLFn
 	initWSLFn = fn
+	previousResolver := resolveWSLPayloadFn
+	resolveWSLPayloadFn = func(string) (enginebin.Resolved, error) {
+		return enginebin.Resolved{Path: "test-linux-engine", Kind: enginebin.KindWSLPayload}, nil
+	}
 	t.Cleanup(func() {
 		initWSLFn = prev
+		resolveWSLPayloadFn = previousResolver
 	})
 }
 

--- a/frontend/cli-go/internal/app/wsl_paths.go
+++ b/frontend/cli-go/internal/app/wsl_paths.go
@@ -55,14 +55,18 @@ func resolveWSLSettings(cfg config.Config, dirs paths.Dirs, daemonPath string) (
 
 	engineBinary := daemonPath
 	if cfg.Engine.WSL.EnginePath != "" {
-		engineBinary = cfg.Engine.WSL.EnginePath
+		engineBinary = strings.TrimSpace(cfg.Engine.WSL.EnginePath)
 	}
-	wslDaemonPath, err := windowsToWSLPath(engineBinary)
-	if err != nil {
-		if mode == "required" {
-			return "", "", "", "", "", "", "", err
+	wslDaemonPath := engineBinary
+	if !strings.HasPrefix(wslDaemonPath, "/") {
+		var err error
+		wslDaemonPath, err = windowsToWSLPath(engineBinary)
+		if err != nil {
+			if mode == "required" {
+				return "", "", "", "", "", "", "", err
+			}
+			return daemonPath, "", "", "", "", "", "", nil
 		}
-		return daemonPath, "", "", "", "", "", "", nil
 	}
 
 	statePath := filepath.Join(dirs.StateDir, "engine.json")

--- a/frontend/cli-go/internal/cli/commands_run_test.go
+++ b/frontend/cli-go/internal/cli/commands_run_test.go
@@ -255,16 +255,18 @@ func TestRunClientLocalAutoAutostartDisabled(t *testing.T) {
 	}
 }
 
-func TestRunClientLocalAutoMissingDaemonPath(t *testing.T) {
+func TestRunClientLocalAutoMissingDiscoverableEngine(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
 	_, err := runClient(context.Background(), RunOptions{
 		Mode:      "local",
 		Endpoint:  "auto",
 		Autostart: true,
+		RunDir:    t.TempDir(),
 		StateDir:  t.TempDir(),
 		Timeout:   time.Second,
 	})
-	if err == nil || !strings.Contains(err.Error(), "local daemon path") {
-		t.Fatalf("expected daemon path error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "resolve host engine") {
+		t.Fatalf("expected host discovery error, got %v", err)
 	}
 }
 

--- a/frontend/cli-go/internal/cli/init_usage.go
+++ b/frontend/cli-go/internal/cli/init_usage.go
@@ -18,6 +18,7 @@ func PrintInitUsage(w io.Writer) {
 	io.WriteString(w, "  --store-size <NGB>      Image store size (default: 100GB)\n")
 	io.WriteString(w, "  --reinit                Recreate the store (destructive)\n")
 	io.WriteString(w, "  --engine <path>         Engine binary path\n")
+	io.WriteString(w, "  --wsl-engine <path>     Linux engine binary to install into WSL\n")
 	io.WriteString(w, "  --shared-cache          Enable shared cache in local config\n")
 	io.WriteString(w, "  --no-start              Skip WSL auto-start during init\n")
 	io.WriteString(w, "  --distro <name>         WSL distro name\n\n")

--- a/frontend/cli-go/internal/daemon/engine_discovery_test.go
+++ b/frontend/cli-go/internal/daemon/engine_discovery_test.go
@@ -1,0 +1,120 @@
+package daemon
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sqlrs/cli/internal/enginebin"
+)
+
+func TestMain(m *testing.M) {
+	resolveHostEngineForStartFn = func(candidate string) (enginebin.Resolved, error) {
+		if strings.TrimSpace(candidate) == "" {
+			return enginebin.Resolved{}, errors.New("host engine was not found")
+		}
+		return enginebin.Resolved{Path: candidate, Kind: enginebin.KindHost, Origin: enginebin.OriginConfig}, nil
+	}
+	validateWSLEngineForStartFn = func(context.Context, string, string) error { return nil }
+	os.Exit(m.Run())
+}
+
+func withStartHostResolver(t *testing.T, fn func(string) (enginebin.Resolved, error)) {
+	t.Helper()
+	previous := resolveHostEngineForStartFn
+	resolveHostEngineForStartFn = fn
+	t.Cleanup(func() { resolveHostEngineForStartFn = previous })
+}
+
+func withStartWSLValidator(t *testing.T, fn func(context.Context, string, string) error) {
+	t.Helper()
+	previous := validateWSLEngineForStartFn
+	validateWSLEngineForStartFn = fn
+	t.Cleanup(func() { validateWSLEngineForStartFn = previous })
+}
+
+func TestConnectOrStartDefersHostResolutionUntilAutostart(t *testing.T) {
+	server, stateDir := healthyEngineFixture(t)
+	defer server.Close()
+	withStartHostResolver(t, func(string) (enginebin.Resolved, error) {
+		t.Fatal("healthy engine must be used without resolving its executable")
+		return enginebin.Resolved{}, nil
+	})
+
+	result, err := ConnectOrStart(context.Background(), ConnectOptions{
+		Endpoint:      "auto",
+		Autostart:     true,
+		DaemonPath:    "missing-engine",
+		RunDir:        stateDir,
+		StateDir:      stateDir,
+		ClientTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatalf("ConnectOrStart: %v", err)
+	}
+	if result.Endpoint != server.URL {
+		t.Fatalf("endpoint=%q, want %q", result.Endpoint, server.URL)
+	}
+}
+
+func TestConnectOrStartMissingWSLEngineReturnsInitHint(t *testing.T) {
+	withStartWSLValidator(t, func(context.Context, string, string) error {
+		return errors.New("exit status 1")
+	})
+	stateDir := t.TempDir()
+	_, err := ConnectOrStart(context.Background(), ConnectOptions{
+		Endpoint:      "auto",
+		Autostart:     true,
+		DaemonPath:    "/home/user/.local/lib/sqlrs/sqlrs-engine",
+		RunDir:        stateDir,
+		StateDir:      stateDir,
+		WSLDistro:     "Ubuntu",
+		ClientTimeout: time.Second,
+	})
+	if err == nil || !strings.Contains(err.Error(), "rerun sqlrs init local") {
+		t.Fatalf("expected init repair hint, got %v", err)
+	}
+}
+
+func TestConnectOrStartMissingWSLEnginePathReturnsInitHint(t *testing.T) {
+	stateDir := t.TempDir()
+	_, err := ConnectOrStart(context.Background(), ConnectOptions{
+		Endpoint:      "auto",
+		Autostart:     true,
+		RunDir:        stateDir,
+		StateDir:      stateDir,
+		WSLDistro:     "Ubuntu",
+		ClientTimeout: time.Second,
+	})
+	if err == nil || !strings.Contains(err.Error(), "rerun sqlrs init local") {
+		t.Fatalf("expected init repair hint, got %v", err)
+	}
+}
+
+func healthyEngineFixture(t *testing.T) (*httptest.Server, string) {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/health" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true,"instanceId":"inst"}`)
+	}))
+	stateDir := t.TempDir()
+	if err := WriteEngineState(filepath.Join(stateDir, "engine.json"), EngineState{
+		Endpoint:   server.URL,
+		InstanceID: "inst",
+	}); err != nil {
+		server.Close()
+		t.Fatalf("WriteEngineState: %v", err)
+	}
+	return server, stateDir
+}

--- a/frontend/cli-go/internal/daemon/engine_discovery_test.go
+++ b/frontend/cli-go/internal/daemon/engine_discovery_test.go
@@ -64,6 +64,52 @@ func TestConnectOrStartDefersHostResolutionUntilAutostart(t *testing.T) {
 	}
 }
 
+func TestConnectOrStartDefersHostResolutionUntilLockedHealthRecheck(t *testing.T) {
+	healthChecks := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/health" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		healthChecks++
+		if healthChecks < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"ok":true,"instanceId":"inst"}`)
+	}))
+	defer server.Close()
+
+	stateDir := t.TempDir()
+	if err := WriteEngineState(filepath.Join(stateDir, "engine.json"), EngineState{
+		Endpoint:   server.URL,
+		InstanceID: "inst",
+	}); err != nil {
+		t.Fatalf("WriteEngineState: %v", err)
+	}
+	withStartHostResolver(t, func(string) (enginebin.Resolved, error) {
+		t.Fatal("engine that became healthy before the locked recheck must not be resolved")
+		return enginebin.Resolved{}, nil
+	})
+
+	result, err := ConnectOrStart(context.Background(), ConnectOptions{
+		Endpoint:       "auto",
+		Autostart:      true,
+		DaemonPath:     "missing-engine",
+		RunDir:         stateDir,
+		StateDir:       stateDir,
+		StartupTimeout: time.Second,
+		ClientTimeout:  time.Second,
+	})
+	if err != nil {
+		t.Fatalf("ConnectOrStart: %v", err)
+	}
+	if result.Endpoint != server.URL {
+		t.Fatalf("endpoint=%q, want %q", result.Endpoint, server.URL)
+	}
+}
+
 func TestConnectOrStartMissingWSLEngineReturnsInitHint(t *testing.T) {
 	withStartWSLValidator(t, func(context.Context, string, string) error {
 		return errors.New("exit status 1")

--- a/frontend/cli-go/internal/daemon/orchestrator.go
+++ b/frontend/cli-go/internal/daemon/orchestrator.go
@@ -17,9 +17,25 @@ import (
 	"sync"
 	"time"
 	"unicode"
+
+	"github.com/sqlrs/cli/internal/enginebin"
 )
 
 var isWindows = runtime.GOOS == "windows"
+
+var resolveHostEngineForStartFn = func(candidate string) (enginebin.Resolved, error) {
+	return (enginebin.Resolver{}).Resolve(enginebin.Request{
+		Kind:       enginebin.KindHost,
+		TargetOS:   runtime.GOOS,
+		TargetArch: runtime.GOARCH,
+		ConfigPath: candidate,
+	})
+}
+
+var validateWSLEngineForStartFn = func(ctx context.Context, distro, enginePath string) error {
+	_, err := runWSLCommandFn(ctx, distro, "test", "-x", enginePath)
+	return err
+}
 
 var cachedEngineStates = struct {
 	mu sync.Mutex
@@ -98,12 +114,22 @@ LONG_PATH:
 		logVerbose(opts.Verbose, "engine not running and autostart disabled")
 		return ConnectResult{}, fmt.Errorf("local engine is not running")
 	}
-	if opts.DaemonPath == "" {
-		return ConnectResult{}, fmt.Errorf("local daemon path is not configured")
-	}
-
 	if opts.RunDir == "" {
 		return ConnectResult{}, fmt.Errorf("runDir is not configured")
+	}
+	if strings.TrimSpace(opts.WSLDistro) != "" {
+		if strings.TrimSpace(opts.DaemonPath) == "" {
+			return ConnectResult{}, fmt.Errorf("configured WSL engine is missing; rerun sqlrs init local")
+		}
+		if err := validateWSLEngineForStartFn(ctx, opts.WSLDistro, opts.DaemonPath); err != nil {
+			return ConnectResult{}, fmt.Errorf("configured WSL engine %q is unavailable: %v; rerun sqlrs init local", opts.DaemonPath, err)
+		}
+	} else {
+		resolved, err := resolveHostEngineForStartFn(opts.DaemonPath)
+		if err != nil {
+			return ConnectResult{}, fmt.Errorf("resolve host engine: %w", err)
+		}
+		opts.DaemonPath = resolved.Path
 	}
 
 	if err := util.EnsureDir(opts.RunDir); err != nil {

--- a/frontend/cli-go/internal/daemon/orchestrator.go
+++ b/frontend/cli-go/internal/daemon/orchestrator.go
@@ -117,20 +117,6 @@ LONG_PATH:
 	if opts.RunDir == "" {
 		return ConnectResult{}, fmt.Errorf("runDir is not configured")
 	}
-	if strings.TrimSpace(opts.WSLDistro) != "" {
-		if strings.TrimSpace(opts.DaemonPath) == "" {
-			return ConnectResult{}, fmt.Errorf("configured WSL engine is missing; rerun sqlrs init local")
-		}
-		if err := validateWSLEngineForStartFn(ctx, opts.WSLDistro, opts.DaemonPath); err != nil {
-			return ConnectResult{}, fmt.Errorf("configured WSL engine %q is unavailable: %v; rerun sqlrs init local", opts.DaemonPath, err)
-		}
-	} else {
-		resolved, err := resolveHostEngineForStartFn(opts.DaemonPath)
-		if err != nil {
-			return ConnectResult{}, fmt.Errorf("resolve host engine: %w", err)
-		}
-		opts.DaemonPath = resolved.Path
-	}
 
 	if err := util.EnsureDir(opts.RunDir); err != nil {
 		return ConnectResult{}, err
@@ -158,6 +144,20 @@ LONG_PATH:
 
 	if mustStartDaemon {
 		logVerbose(opts.Verbose, "healthy engine rejected auth after refresh; starting new daemon")
+	}
+	if strings.TrimSpace(opts.WSLDistro) != "" {
+		if strings.TrimSpace(opts.DaemonPath) == "" {
+			return ConnectResult{}, fmt.Errorf("configured WSL engine is missing; rerun sqlrs init local")
+		}
+		if err := validateWSLEngineForStartFn(ctx, opts.WSLDistro, opts.DaemonPath); err != nil {
+			return ConnectResult{}, fmt.Errorf("configured WSL engine %q is unavailable: %v; rerun sqlrs init local", opts.DaemonPath, err)
+		}
+	} else {
+		resolved, err := resolveHostEngineForStartFn(opts.DaemonPath)
+		if err != nil {
+			return ConnectResult{}, fmt.Errorf("resolve host engine: %w", err)
+		}
+		opts.DaemonPath = resolved.Path
 	}
 	logsDir := filepath.Join(opts.StateDir, "logs")
 	if err := util.EnsureDir(logsDir); err != nil {

--- a/frontend/cli-go/internal/daemon/orchestrator_coverage_pass3_test.go
+++ b/frontend/cli-go/internal/daemon/orchestrator_coverage_pass3_test.go
@@ -244,7 +244,7 @@ func writeHealthyDaemonScript(t *testing.T, dir, endpoint, instanceID, token str
 			"shift\r\n" +
 			"goto parse\r\n" +
 			":parsed\r\n" +
-			"powershell -NoProfile -Command \"Start-Sleep -Milliseconds 200\"\r\n" +
+			"ping -n 2 127.0.0.1 >nul\r\n" +
 			fmt.Sprintf("> \"%%state%%\" echo {\"endpoint\":\"%s\",\"instanceId\":\"%s\",\"authToken\":\"%s\"}\r\n", endpoint, instanceID, token) +
 			"timeout /t 2 /nobreak >nul\r\n"
 		if err := os.WriteFile(path, []byte(content), 0o700); err != nil {

--- a/frontend/cli-go/internal/daemon/orchestrator_test.go
+++ b/frontend/cli-go/internal/daemon/orchestrator_test.go
@@ -336,8 +336,8 @@ func TestConnectOrStartMissingDaemonPath(t *testing.T) {
 		RunDir:    filepath.Join(temp, "run"),
 		StateDir:  temp,
 	})
-	if err == nil || !strings.Contains(err.Error(), "daemon path") {
-		t.Fatalf("expected daemon path error, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "resolve host engine") {
+		t.Fatalf("expected host discovery error, got %v", err)
 	}
 }
 

--- a/frontend/cli-go/internal/enginebin/resolver.go
+++ b/frontend/cli-go/internal/enginebin/resolver.go
@@ -1,0 +1,282 @@
+// Package enginebin resolves and validates local sqlrs engine executables.
+// Its precedence and ownership rules are defined in
+// docs/architecture/local-engine-binary-discovery-component-structure.md.
+package enginebin
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Kind identifies the runtime role of an engine binary.
+type Kind string
+
+const (
+	// KindHost is the native engine for the CLI host operating system.
+	KindHost Kind = "host"
+	// KindWSLPayload is a Linux engine distributed for installation into WSL.
+	KindWSLPayload Kind = "wsl"
+)
+
+// Origin identifies the discovery source that supplied a resolved binary.
+type Origin string
+
+const (
+	OriginExplicit    Origin = "explicit"
+	OriginEnvironment Origin = "environment"
+	OriginConfig      Origin = "config"
+	OriginBundle      Origin = "bundle"
+	OriginPath        Origin = "PATH"
+)
+
+// Format is the detected executable container format.
+type Format string
+
+const (
+	FormatELF   Format = "elf"
+	FormatPE    Format = "pe"
+	FormatMachO Format = "macho"
+)
+
+// Request describes one binary role and its ordered override candidates.
+type Request struct {
+	Kind            Kind
+	TargetOS        string
+	TargetArch      string
+	ExplicitPath    string
+	EnvironmentPath string
+	ConfigPath      string
+}
+
+// Resolved is a validated engine candidate.
+type Resolved struct {
+	Path   string
+	Kind   Kind
+	Origin Origin
+	Format Format
+	Arch   string
+}
+
+// Validation describes the executable metadata verified by Validate.
+type Validation struct {
+	Format Format
+	Arch   string
+}
+
+// Resolver provides injectable host lookups for deterministic tests.
+type Resolver struct {
+	Executable func() (string, error)
+	LookPath   func(string) (string, error)
+}
+
+// Resolve applies the documented override, bundle, and PATH precedence.
+func (r Resolver) Resolve(req Request) (Resolved, error) {
+	if req.Kind != KindHost && req.Kind != KindWSLPayload {
+		return Resolved{}, fmt.Errorf("unknown engine runtime %q", req.Kind)
+	}
+	if strings.TrimSpace(req.TargetOS) == "" || strings.TrimSpace(req.TargetArch) == "" {
+		return Resolved{}, fmt.Errorf("engine %s target OS and architecture are required", req.Kind)
+	}
+
+	ordered := []struct {
+		origin Origin
+		path   string
+	}{
+		{OriginExplicit, req.ExplicitPath},
+		{OriginEnvironment, req.EnvironmentPath},
+		{OriginConfig, req.ConfigPath},
+	}
+	for _, candidate := range ordered {
+		if strings.TrimSpace(candidate.path) == "" {
+			continue
+		}
+		return resolveCandidate(req, candidate.origin, candidate.path)
+	}
+
+	executableFn := r.Executable
+	if executableFn == nil {
+		executableFn = os.Executable
+	}
+	executablePath, executableErr := executableFn()
+	if executableErr == nil && strings.TrimSpace(executablePath) != "" {
+		bundlePath := bundleCandidate(filepath.Dir(executablePath), req)
+		if _, err := os.Stat(bundlePath); err == nil {
+			return resolveCandidate(req, OriginBundle, bundlePath)
+		} else if !os.IsNotExist(err) {
+			return Resolved{}, fmt.Errorf("validate %s bundle engine %q: %w", req.Kind, bundlePath, err)
+		}
+	}
+
+	if req.Kind == KindHost {
+		lookPathFn := r.LookPath
+		if lookPathFn == nil {
+			lookPathFn = exec.LookPath
+		}
+		name := "sqlrs-engine"
+		if req.TargetOS == "windows" {
+			name += ".exe"
+		}
+		if found, err := lookPathFn(name); err == nil {
+			return resolveCandidate(req, OriginPath, found)
+		}
+	}
+
+	envName := "SQLRS_DAEMON_PATH"
+	attempts := "explicit, environment, config, bundle, PATH"
+	if req.Kind == KindWSLPayload {
+		envName = "SQLRS_WSL_ENGINE_PATH"
+		attempts = "explicit, environment, config, bundle"
+	}
+	return Resolved{}, fmt.Errorf("%s engine was not found; attempted %s; set %s or rerun sqlrs init local with the matching engine flag", req.Kind, attempts, envName)
+}
+
+func resolveCandidate(req Request, origin Origin, candidate string) (Resolved, error) {
+	pathValue, err := filepath.Abs(filepath.Clean(strings.TrimSpace(candidate)))
+	if err != nil {
+		return Resolved{}, fmt.Errorf("resolve %s %s engine %q: %w", origin, req.Kind, candidate, err)
+	}
+	validation, err := Validate(pathValue, req.TargetOS, req.TargetArch)
+	if err != nil {
+		return Resolved{}, fmt.Errorf("validate %s %s engine %q: %w", origin, req.Kind, pathValue, err)
+	}
+	return Resolved{Path: pathValue, Kind: req.Kind, Origin: origin, Format: validation.Format, Arch: validation.Arch}, nil
+}
+
+func bundleCandidate(root string, req Request) string {
+	if req.Kind == KindWSLPayload {
+		return filepath.Join(root, "libexec", "linux-"+req.TargetArch, "sqlrs-engine")
+	}
+	name := "sqlrs-engine"
+	if req.TargetOS == "windows" {
+		name += ".exe"
+	}
+	return filepath.Join(root, name)
+}
+
+// Validate confirms that path is a regular executable for targetOS/targetArch.
+func Validate(path, targetOS, targetArch string) (Validation, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return Validation{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return Validation{}, fmt.Errorf("not a regular file")
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		return Validation{}, err
+	}
+	defer file.Close()
+
+	format, arch, err := inspect(file)
+	if err != nil {
+		return Validation{}, err
+	}
+	wantFormat, err := formatForOS(targetOS)
+	if err != nil {
+		return Validation{}, err
+	}
+	if format != wantFormat {
+		return Validation{}, fmt.Errorf("format %s is incompatible with %s (expected %s)", format, targetOS, wantFormat)
+	}
+	if arch != targetArch {
+		return Validation{}, fmt.Errorf("architecture %s is incompatible with %s", arch, targetArch)
+	}
+	return Validation{Format: format, Arch: arch}, nil
+}
+
+func inspect(file *os.File) (Format, string, error) {
+	header := make([]byte, 64)
+	n, err := io.ReadFull(file, header)
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return "", "", fmt.Errorf("read executable header: %w", err)
+	}
+	if n < 4 {
+		return "", "", fmt.Errorf("read executable header: file is too short")
+	}
+	if string(header[:4]) == "\x7fELF" {
+		if n < 20 {
+			return "", "", fmt.Errorf("read ELF header: file is too short")
+		}
+		if header[5] != 1 {
+			return "", "", fmt.Errorf("unsupported ELF byte order")
+		}
+		arch, err := elfArch(binary.LittleEndian.Uint16(header[18:20]))
+		return FormatELF, arch, err
+	}
+	if string(header[:2]) == "MZ" {
+		if n < 64 {
+			return "", "", fmt.Errorf("read DOS header: file is too short")
+		}
+		offset := int64(binary.LittleEndian.Uint32(header[0x3c:0x40]))
+		peHeader := make([]byte, 6)
+		if _, err := file.ReadAt(peHeader, offset); err != nil {
+			return "", "", fmt.Errorf("read PE header: %w", err)
+		}
+		if string(peHeader[:4]) != "PE\x00\x00" {
+			return "", "", fmt.Errorf("invalid PE signature")
+		}
+		arch, err := peArch(binary.LittleEndian.Uint16(peHeader[4:6]))
+		return FormatPE, arch, err
+	}
+	if n < 8 {
+		return "", "", fmt.Errorf("read Mach-O header: file is too short")
+	}
+	magic := binary.LittleEndian.Uint32(header[:4])
+	if magic == 0xfeedface || magic == 0xfeedfacf {
+		arch, err := machoArch(binary.LittleEndian.Uint32(header[4:8]))
+		return FormatMachO, arch, err
+	}
+	return "", "", fmt.Errorf("unrecognized executable format")
+}
+
+func formatForOS(targetOS string) (Format, error) {
+	switch targetOS {
+	case "linux":
+		return FormatELF, nil
+	case "windows":
+		return FormatPE, nil
+	case "darwin":
+		return FormatMachO, nil
+	default:
+		return "", fmt.Errorf("unsupported target OS %q", targetOS)
+	}
+}
+
+func elfArch(machine uint16) (string, error) {
+	switch machine {
+	case 62:
+		return "amd64", nil
+	case 183:
+		return "arm64", nil
+	default:
+		return "", fmt.Errorf("unsupported ELF machine %d", machine)
+	}
+}
+
+func peArch(machine uint16) (string, error) {
+	switch machine {
+	case 0x8664:
+		return "amd64", nil
+	case 0xaa64:
+		return "arm64", nil
+	default:
+		return "", fmt.Errorf("unsupported PE machine %#x", machine)
+	}
+}
+
+func machoArch(cpu uint32) (string, error) {
+	switch cpu {
+	case 0x01000007:
+		return "amd64", nil
+	case 0x0100000c:
+		return "arm64", nil
+	default:
+		return "", fmt.Errorf("unsupported Mach-O CPU %#x", cpu)
+	}
+}

--- a/frontend/cli-go/internal/enginebin/resolver.go
+++ b/frontend/cli-go/internal/enginebin/resolver.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 )
 
@@ -166,6 +167,9 @@ func Validate(path, targetOS, targetArch string) (Validation, error) {
 	}
 	if !info.Mode().IsRegular() {
 		return Validation{}, fmt.Errorf("not a regular file")
+	}
+	if targetOS != "windows" && runtime.GOOS != "windows" && info.Mode().Perm()&0o111 == 0 {
+		return Validation{}, fmt.Errorf("file is not executable")
 	}
 	file, err := os.Open(path)
 	if err != nil {

--- a/frontend/cli-go/internal/enginebin/resolver_test.go
+++ b/frontend/cli-go/internal/enginebin/resolver_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -100,6 +101,26 @@ func TestExplicitInvalidCandidateDoesNotFallThrough(t *testing.T) {
 	_, err := resolver.Resolve(Request{Kind: KindHost, TargetOS: "linux", TargetArch: "amd64", ExplicitPath: missing})
 	if err == nil || !strings.Contains(err.Error(), "explicit") || !strings.Contains(err.Error(), missing) {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestResolveHostRejectsNonExecutablePOSIXCandidate(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not expose POSIX execute bits")
+	}
+	root := t.TempDir()
+	candidate := writeELF(t, root, "sqlrs-engine", 62)
+	if err := os.Chmod(candidate, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := (Resolver{}).Resolve(Request{
+		Kind:         KindHost,
+		TargetOS:     "linux",
+		TargetArch:   "amd64",
+		ExplicitPath: candidate,
+	})
+	if err == nil || !strings.Contains(err.Error(), "not executable") {
+		t.Fatalf("expected execute-permission error, got %v", err)
 	}
 }
 

--- a/frontend/cli-go/internal/enginebin/resolver_test.go
+++ b/frontend/cli-go/internal/enginebin/resolver_test.go
@@ -1,0 +1,342 @@
+package enginebin
+
+import (
+	"encoding/binary"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveHostPrecedence(t *testing.T) {
+	root := t.TempDir()
+	executable := filepath.Join(root, "sqlrs")
+	explicit := writeELF(t, root, "explicit", 62)
+	environment := writeELF(t, root, "environment", 62)
+	configured := writeELF(t, root, "configured", 62)
+	_ = writeELF(t, root, "sqlrs-engine", 62)
+	pathCandidate := writeELF(t, root, "path-engine", 62)
+	resolver := Resolver{
+		Executable: func() (string, error) { return executable, nil },
+		LookPath:   func(string) (string, error) { return pathCandidate, nil },
+	}
+
+	tests := []struct {
+		name, explicit, environment, configured, wantPath string
+		wantOrigin                                        Origin
+	}{
+		{"explicit", explicit, environment, configured, explicit, OriginExplicit},
+		{"environment", "", environment, configured, environment, OriginEnvironment},
+		{"config", "", "", configured, configured, OriginConfig},
+		{"bundle", "", "", "", filepath.Join(root, "sqlrs-engine"), OriginBundle},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolver.Resolve(Request{Kind: KindHost, TargetOS: "linux", TargetArch: "amd64", ExplicitPath: tt.explicit, EnvironmentPath: tt.environment, ConfigPath: tt.configured})
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if got.Path != tt.wantPath || got.Origin != tt.wantOrigin {
+				t.Fatalf("got path=%q origin=%q, want path=%q origin=%q", got.Path, got.Origin, tt.wantPath, tt.wantOrigin)
+			}
+		})
+	}
+
+	if err := os.Remove(filepath.Join(root, "sqlrs-engine")); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolver.Resolve(Request{Kind: KindHost, TargetOS: "linux", TargetArch: "amd64"})
+	if err != nil {
+		t.Fatalf("PATH fallback: %v", err)
+	}
+	if got.Path != pathCandidate || got.Origin != OriginPath {
+		t.Fatalf("PATH fallback got %+v", got)
+	}
+}
+
+func TestResolveWSLPayloadPrecedenceAndNeverUsesPath(t *testing.T) {
+	root := t.TempDir()
+	bundle := writeELF(t, filepath.Join(root, "libexec", "linux-amd64"), "sqlrs-engine", 62)
+	environment := writeELF(t, root, "env-linux-engine", 62)
+	configured := writeELF(t, root, "configured-linux-engine", 62)
+	lookCalls := 0
+	resolver := Resolver{
+		Executable: func() (string, error) { return filepath.Join(root, "sqlrs.exe"), nil },
+		LookPath: func(string) (string, error) {
+			lookCalls++
+			return "", errors.New("must not be called")
+		},
+	}
+
+	for _, tt := range []struct {
+		name, environment, configured, want string
+		origin                              Origin
+	}{
+		{"environment", environment, configured, environment, OriginEnvironment},
+		{"config", "", configured, configured, OriginConfig},
+		{"bundle", "", "", bundle, OriginBundle},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolver.Resolve(Request{Kind: KindWSLPayload, TargetOS: "linux", TargetArch: "amd64", EnvironmentPath: tt.environment, ConfigPath: tt.configured})
+			if err != nil {
+				t.Fatalf("Resolve: %v", err)
+			}
+			if got.Path != tt.want || got.Origin != tt.origin {
+				t.Fatalf("got %+v, want path=%q origin=%q", got, tt.want, tt.origin)
+			}
+		})
+	}
+	if lookCalls != 0 {
+		t.Fatalf("WSL payload unexpectedly searched PATH %d times", lookCalls)
+	}
+}
+
+func TestExplicitInvalidCandidateDoesNotFallThrough(t *testing.T) {
+	root := t.TempDir()
+	writeELF(t, root, "sqlrs-engine", 62)
+	missing := filepath.Join(root, "missing")
+	resolver := Resolver{Executable: func() (string, error) { return filepath.Join(root, "sqlrs"), nil }}
+	_, err := resolver.Resolve(Request{Kind: KindHost, TargetOS: "linux", TargetArch: "amd64", ExplicitPath: missing})
+	if err == nil || !strings.Contains(err.Error(), "explicit") || !strings.Contains(err.Error(), missing) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBundleResolutionUsesExecutableDirectoryNotWorkingDirectory(t *testing.T) {
+	root := t.TempDir()
+	want := writeELF(t, root, "sqlrs-engine", 62)
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(old) })
+	resolver := Resolver{Executable: func() (string, error) { return filepath.Join(root, "sqlrs"), nil }}
+	got, err := resolver.Resolve(Request{Kind: KindHost, TargetOS: "linux", TargetArch: "amd64"})
+	if err != nil || got.Path != want {
+		t.Fatalf("got %+v err=%v, want %q", got, err, want)
+	}
+}
+
+func TestValidateExecutableFormatsAndArchitectures(t *testing.T) {
+	root := t.TempDir()
+	linuxAMD64 := writeELF(t, root, "linux-amd64", 62)
+	linuxARM64 := writeELF(t, root, "linux-arm64", 183)
+	windowsAMD64 := writePE(t, root, "windows-amd64.exe", 0x8664)
+	macAMD64 := writeMachO(t, root, "darwin-amd64", 0x01000007)
+	for _, tt := range []struct {
+		name, path, os, arch string
+		format               Format
+	}{
+		{"elf", linuxAMD64, "linux", "amd64", FormatELF},
+		{"pe", windowsAMD64, "windows", "amd64", FormatPE},
+		{"macho", macAMD64, "darwin", "amd64", FormatMachO},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Validate(tt.path, tt.os, tt.arch)
+			if err != nil || got.Format != tt.format || got.Arch != tt.arch {
+				t.Fatalf("got %+v err=%v", got, err)
+			}
+		})
+	}
+	for _, tt := range []struct{ name, path, os, arch string }{
+		{"wrong architecture", linuxARM64, "linux", "amd64"},
+		{"wrong format", windowsAMD64, "linux", "amd64"},
+		{"missing", filepath.Join(root, "missing"), "linux", "amd64"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := Validate(tt.path, tt.os, tt.arch); err == nil {
+				t.Fatal("expected validation error")
+			}
+		})
+	}
+	short := filepath.Join(root, "short")
+	if err := os.WriteFile(short, []byte{0x7f, 'E'}, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Validate(short, "linux", "amd64"); err == nil {
+		t.Fatal("expected truncated binary error")
+	}
+	if _, err := Validate(root, "linux", "amd64"); err == nil {
+		t.Fatal("expected directory validation error")
+	}
+}
+
+func TestResolutionErrorNamesRuntimeAndAttemptedSources(t *testing.T) {
+	root := t.TempDir()
+	resolver := Resolver{
+		Executable: func() (string, error) { return filepath.Join(root, "sqlrs.exe"), nil },
+		LookPath:   func(string) (string, error) { return "", errors.New("not found") },
+	}
+	_, err := resolver.Resolve(Request{Kind: KindHost, TargetOS: "windows", TargetArch: "amd64"})
+	if err == nil {
+		t.Fatal("expected resolution error")
+	}
+	for _, fragment := range []string{"host", "bundle", "PATH", "SQLRS_DAEMON_PATH"} {
+		if !strings.Contains(err.Error(), fragment) {
+			t.Fatalf("error %q does not contain %q", err, fragment)
+		}
+	}
+}
+
+func TestResolveRejectsInvalidRequestsAndBrokenCandidates(t *testing.T) {
+	resolver := Resolver{Executable: func() (string, error) { return "", errors.New("executable unavailable") }, LookPath: func(string) (string, error) { return "", errors.New("not found") }}
+	for _, request := range []Request{
+		{Kind: "other", TargetOS: "linux", TargetArch: "amd64"},
+		{Kind: KindHost, TargetArch: "amd64"},
+		{Kind: KindHost, TargetOS: "linux"},
+	} {
+		if _, err := resolver.Resolve(request); err == nil {
+			t.Fatalf("expected invalid request error for %+v", request)
+		}
+	}
+
+	root := t.TempDir()
+	bundleDir := filepath.Join(root, "sqlrs-engine")
+	if err := os.Mkdir(bundleDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	resolver = Resolver{Executable: func() (string, error) { return filepath.Join(root, "sqlrs"), nil }}
+	if _, err := resolver.Resolve(Request{Kind: KindHost, TargetOS: "linux", TargetArch: "amd64"}); err == nil || !strings.Contains(err.Error(), "not a regular file") {
+		t.Fatalf("expected corrupt bundle error, got %v", err)
+	}
+
+	badPath := writeBinary(t, t.TempDir(), "sqlrs-engine", []byte("not an executable"))
+	resolver = Resolver{Executable: func() (string, error) { return "", errors.New("unavailable") }, LookPath: func(string) (string, error) { return badPath, nil }}
+	if _, err := resolver.Resolve(Request{Kind: KindHost, TargetOS: "linux", TargetArch: "amd64"}); err == nil || !strings.Contains(err.Error(), "PATH") {
+		t.Fatalf("expected invalid PATH candidate error, got %v", err)
+	}
+
+	resolver = Resolver{Executable: func() (string, error) { return filepath.Join(t.TempDir(), "sqlrs.exe"), nil }, LookPath: func(string) (string, error) { t.Fatal("WSL resolver searched PATH"); return "", nil }}
+	if _, err := resolver.Resolve(Request{Kind: KindWSLPayload, TargetOS: "linux", TargetArch: "amd64"}); err == nil || !strings.Contains(err.Error(), "SQLRS_WSL_ENGINE_PATH") {
+		t.Fatalf("expected WSL resolution diagnostic, got %v", err)
+	}
+}
+
+func TestResolveUsesDefaultHostLookups(t *testing.T) {
+	if os.PathSeparator != '\\' {
+		t.Skip("this test supplies a PE executable through Windows PATH")
+	}
+	root := t.TempDir()
+	want := writePE(t, root, "sqlrs-engine.exe", 0x8664)
+	t.Setenv("PATH", root)
+	got, err := (Resolver{}).Resolve(Request{Kind: KindHost, TargetOS: "windows", TargetArch: "amd64"})
+	if err != nil {
+		t.Fatalf("Resolve with default lookups: %v", err)
+	}
+	if got.Path != want || got.Origin != OriginPath {
+		t.Fatalf("got %+v, want PATH candidate %q", got, want)
+	}
+}
+
+func TestValidateRejectsMalformedExecutableHeaders(t *testing.T) {
+	root := t.TempDir()
+	cases := []struct {
+		name, targetOS string
+		data           []byte
+	}{
+		{"tiny", "linux", []byte{1, 2, 3}},
+		{"short elf", "linux", []byte{0x7f, 'E', 'L', 'F'}},
+		{"big endian elf", "linux", func() []byte { b := make([]byte, 20); copy(b, []byte{0x7f, 'E', 'L', 'F'}); b[5] = 2; return b }()},
+		{"unknown elf machine", "linux", func() []byte {
+			b := make([]byte, 20)
+			copy(b, []byte{0x7f, 'E', 'L', 'F'})
+			b[5] = 1
+			binary.LittleEndian.PutUint16(b[18:], 1)
+			return b
+		}()},
+		{"short dos", "windows", []byte{'M', 'Z', 0, 0}},
+		{"missing pe header", "windows", func() []byte {
+			b := make([]byte, 64)
+			copy(b, []byte{'M', 'Z'})
+			binary.LittleEndian.PutUint32(b[0x3c:], 1000)
+			return b
+		}()},
+		{"invalid pe signature", "windows", func() []byte {
+			b := make([]byte, 80)
+			copy(b, []byte{'M', 'Z'})
+			binary.LittleEndian.PutUint32(b[0x3c:], 64)
+			copy(b[64:], []byte("NOPE!!"))
+			return b
+		}()},
+		{"unknown pe machine", "windows", func() []byte {
+			b := make([]byte, 80)
+			copy(b, []byte{'M', 'Z'})
+			binary.LittleEndian.PutUint32(b[0x3c:], 64)
+			copy(b[64:], []byte{'P', 'E', 0, 0})
+			return b
+		}()},
+		{"short macho", "darwin", []byte{0xce, 0xfa, 0xed, 0xfe}},
+		{"unknown macho cpu", "darwin", func() []byte { b := make([]byte, 8); binary.LittleEndian.PutUint32(b, 0xfeedfacf); return b }()},
+		{"unknown format", "linux", []byte("plain text")},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeBinary(t, root, strings.ReplaceAll(tt.name, " ", "-"), tt.data)
+			if _, err := Validate(path, tt.targetOS, "amd64"); err == nil {
+				t.Fatal("expected malformed executable error")
+			}
+		})
+	}
+}
+
+func TestValidateSupportsArm64AndRejectsUnknownTargetOS(t *testing.T) {
+	root := t.TempDir()
+	for _, tt := range []struct {
+		path, targetOS string
+	}{
+		{writeELF(t, root, "linux-arm64", 183), "linux"},
+		{writePE(t, root, "windows-arm64", 0xaa64), "windows"},
+		{writeMachO(t, root, "darwin-arm64", 0x0100000c), "darwin"},
+	} {
+		got, err := Validate(tt.path, tt.targetOS, "arm64")
+		if err != nil || got.Arch != "arm64" {
+			t.Fatalf("Validate(%s): got %+v err=%v", tt.targetOS, got, err)
+		}
+	}
+	if _, err := Validate(writeELF(t, root, "unknown-os", 62), "plan9", "amd64"); err == nil || !strings.Contains(err.Error(), "unsupported target OS") {
+		t.Fatalf("expected unsupported OS error, got %v", err)
+	}
+}
+
+func writeELF(t *testing.T, dir, name string, machine uint16) string {
+	t.Helper()
+	data := make([]byte, 64)
+	copy(data, []byte{0x7f, 'E', 'L', 'F'})
+	data[4], data[5] = 2, 1
+	binary.LittleEndian.PutUint16(data[18:20], machine)
+	return writeBinary(t, dir, name, data)
+}
+
+func writePE(t *testing.T, dir, name string, machine uint16) string {
+	t.Helper()
+	data := make([]byte, 128)
+	copy(data, []byte{'M', 'Z'})
+	binary.LittleEndian.PutUint32(data[0x3c:0x40], 0x40)
+	copy(data[0x40:0x44], []byte{'P', 'E', 0, 0})
+	binary.LittleEndian.PutUint16(data[0x44:0x46], machine)
+	return writeBinary(t, dir, name, data)
+}
+
+func writeMachO(t *testing.T, dir, name string, cpu uint32) string {
+	t.Helper()
+	data := make([]byte, 32)
+	binary.LittleEndian.PutUint32(data[0:4], 0xfeedfacf)
+	binary.LittleEndian.PutUint32(data[4:8], cpu)
+	return writeBinary(t, dir, name, data)
+}
+
+func writeBinary(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/scripts/e2e-release/release-local-workflow.test.mjs
+++ b/scripts/e2e-release/release-local-workflow.test.mjs
@@ -32,7 +32,7 @@ run("happy e2e matrix includes platform and snapshot backend axes", () => {
   assert.deepEqual(job.strategy?.matrix?.snapshot_backend, ["copy", "btrfs"]);
 });
 
-run("happy e2e excludes unsupported windows scenario cells", () => {
+run("happy e2e keeps the Windows copy backend covered", () => {
   const workflow = loadWorkflow();
   const job = workflow.jobs?.["e2e-happy"];
   const excluded = job.strategy?.matrix?.exclude || [];
@@ -40,10 +40,7 @@ run("happy e2e excludes unsupported windows scenario cells", () => {
     excluded.some((entry) => entry.platform === "windows" && entry.scenario === "hp-psql-sakila"),
     "missing windows/sakila exclusion"
   );
-  assert.ok(
-    excluded.some((entry) => entry.platform === "windows" && entry.snapshot_backend === "copy"),
-    "missing windows/copy exclusion"
-  );
+  assert.ok(!excluded.some((entry) => entry.platform === "windows" && entry.snapshot_backend === "copy"));
 });
 
 run("linux e2e cell passes snapshot backend to run-scenario", () => {
@@ -86,8 +83,8 @@ run("windows e2e cell provisions WSL and docker prerequisites", () => {
   assert.equal(String(wslStep.if || "").trim(), "matrix.platform == 'windows' && matrix.snapshot_backend == 'btrfs'");
   assert.equal(dockerStep.uses, "docker/setup-docker-action@v4");
   assert.match(String(runStep.run || ""), /sqlrs_bin/);
-  assert.match(String(runStep.run || ""), /engine_windows_bin/);
-  assert.match(String(runStep.run || ""), /engine_linux_bin/);
+  assert.doesNotMatch(String(runStep.run || ""), /engine_windows_bin|engine_linux_bin/);
+  assert.doesNotMatch(String(runStep.run || ""), /--engine|--wsl-engine/);
   assert.match(String(runStep.run || ""), /\$isBtrfs/);
   assert.match(String(runStep.run || ""), /"--store", "dir", \$storeRoot/);
   assert.match(String(runStep.run || ""), /"--store", "image", \$storeImage/);
@@ -95,6 +92,24 @@ run("windows e2e cell provisions WSL and docker prerequisites", () => {
   assert.match(String(runStep.run || ""), /"prepare",\s*"chinook"/);
   assert.match(String(runStep.run || ""), /raw-stdout-run2\.log/);
   assert.match(String(runStep.run || ""), /second pass failed/);
+});
+
+run("windows release archive is self-contained for native and WSL runtimes", () => {
+  const workflow = loadWorkflow();
+  const build = workflow.jobs?.["build-rc"];
+  const windowsBuild = (build.steps || []).find((step) => step.name === "Build engine (windows)");
+  const windowsRelease = (build.steps || []).find((step) => step.name === "Build local release (windows)");
+  assert.match(String(windowsBuild?.run || ""), /GOOS = "linux"/);
+  assert.match(String(windowsRelease?.run || ""), /--wsl-engine-bin/);
+
+  const e2e = workflow.jobs?.["e2e-happy"];
+  assert.equal(
+    (e2e.steps || []).find((step) => step.name === "Download linux rc artifact for WSL engine"),
+    undefined
+  );
+  const extract = (e2e.steps || []).find((step) => step.name === "Extract windows bundle");
+  assert.match(String(extract?.run || ""), /libexec/);
+  assert.match(String(extract?.run || ""), /linux-amd64/);
 });
 
 run("publish RC waits for unified e2e-happy job", () => {

--- a/scripts/release-local.mjs
+++ b/scripts/release-local.mjs
@@ -41,6 +41,34 @@ function isWindowsTarget(goos) {
   return goos === "windows";
 }
 
+function validateExecutable(pathname, goos, goarch, label) {
+  const data = fs.readFileSync(pathname);
+  let format = "unknown";
+  let arch = "unknown";
+  if (data.length >= 20 && data.subarray(0, 4).equals(Buffer.from([0x7f, 0x45, 0x4c, 0x46]))) {
+    format = "linux";
+    const machine = data.readUInt16LE(18);
+    arch = machine === 62 ? "amd64" : machine === 183 ? "arm64" : "unknown";
+  } else if (data.length >= 64 && data.subarray(0, 2).toString("ascii") === "MZ") {
+    const peOffset = data.readUInt32LE(0x3c);
+    if (data.length >= peOffset + 6 && data.subarray(peOffset, peOffset + 4).equals(Buffer.from("PE\0\0"))) {
+      format = "windows";
+      const machine = data.readUInt16LE(peOffset + 4);
+      arch = machine === 0x8664 ? "amd64" : machine === 0xaa64 ? "arm64" : "unknown";
+    }
+  } else if (data.length >= 8) {
+    const magic = data.readUInt32LE(0);
+    if (magic === 0xfeedface || magic === 0xfeedfacf) {
+      format = "darwin";
+      const cpu = data.readUInt32LE(4);
+      arch = cpu === 0x01000007 ? "amd64" : cpu === 0x0100000c ? "arm64" : "unknown";
+    }
+  }
+  if (format !== goos || arch !== goarch) {
+    throw new Error(`${label} must be ${goos}/${goarch}, detected ${format}/${arch}: ${pathname}`);
+  }
+}
+
 function copyDir(src, dest) {
   if (!fs.existsSync(src)) return;
   fs.cpSync(src, dest, { recursive: true });
@@ -52,6 +80,7 @@ const goos = args.os || process.env.GOOS;
 const goarch = args.arch || process.env.GOARCH;
 const workspace = args.workspace ? path.resolve(args.workspace) : repoRoot;
 const engineBin = args["engine-bin"] || process.env.SQLRS_ENGINE_BIN;
+const wslEngineBin = args["wsl-engine-bin"] || process.env.SQLRS_WSL_ENGINE_BIN;
 
 if (!version) {
   throw new Error("Missing version. Provide --version or SQLRS_VERSION.");
@@ -61,6 +90,12 @@ if (!goos || !goarch) {
 }
 if (!engineBin) {
   throw new Error("Missing engine binary. Provide --engine-bin or SQLRS_ENGINE_BIN.");
+}
+if (isWindowsTarget(goos) && !wslEngineBin) {
+  throw new Error("Missing WSL engine binary. Provide --wsl-engine-bin or SQLRS_WSL_ENGINE_BIN.");
+}
+if (!isWindowsTarget(goos) && wslEngineBin) {
+  throw new Error("--wsl-engine-bin is valid only for Windows release bundles.");
 }
 
 const exeSuffix = isWindowsTarget(goos) ? ".exe" : "";
@@ -80,6 +115,7 @@ ensureDir(stagingDir);
 const cliPath = path.join(distBin, `sqlrs${exeSuffix}`);
 const engineOut = path.join(distBin, `sqlrs-engine${exeSuffix}`);
 const enginePath = path.resolve(engineBin);
+const wslEnginePath = wslEngineBin ? path.resolve(wslEngineBin) : "";
 
 await run({
   cmd: ["go", "build", "-o", cliPath, "./cmd/sqlrs"],
@@ -90,10 +126,23 @@ await run({
 if (!fs.existsSync(enginePath)) {
   throw new Error(`Engine binary not found: ${enginePath}`);
 }
+validateExecutable(enginePath, goos, goarch, "Engine binary");
 fs.copyFileSync(enginePath, engineOut);
+
+if (isWindowsTarget(goos)) {
+  if (!fs.existsSync(wslEnginePath)) {
+    throw new Error(`WSL engine binary not found: ${wslEnginePath}`);
+  }
+  validateExecutable(wslEnginePath, "linux", goarch, "WSL engine binary");
+}
 
 fs.copyFileSync(cliPath, path.join(stagingDir, `sqlrs${exeSuffix}`));
 fs.copyFileSync(engineOut, path.join(stagingDir, `sqlrs-engine${exeSuffix}`));
+if (isWindowsTarget(goos)) {
+  const wslEngineOut = path.join(stagingDir, "libexec", `linux-${goarch}`, "sqlrs-engine");
+  ensureDir(path.dirname(wslEngineOut));
+  fs.copyFileSync(wslEnginePath, wslEngineOut);
+}
 fs.copyFileSync(path.join(repoRoot, "LICENSE"), path.join(stagingDir, "LICENSE"));
 fs.copyFileSync(path.join(repoRoot, "README.md"), path.join(stagingDir, "README.md"));
 


### PR DESCRIPTION
## Summary

- discover native `sqlrs-engine` from explicit overrides, config, the extracted release bundle, then `PATH`
- resolve and validate the Linux WSL payload independently via `--wsl-engine`, `SQLRS_WSL_ENGINE_PATH`, or `libexec/linux-<arch>/sqlrs-engine`
- atomically provision the Linux engine into WSL and repair a missing derived installation on repeated `sqlrs init local`
- keep `sqlrs-engine.exe` for Windows native/copy execution and ship the matching Linux engine in the same Windows archive
- make Windows release E2E consume only the self-contained Windows archive and cover both copy and btrfs
- document the approved contract, component boundary, migration behavior, and roadmap status

## Compatibility

- `--engine` and `orchestrator.daemonPath` remain native-host engine settings
- `--wsl-engine` is local-only and identifies a Linux payload source, not the persisted runtime path
- `--snapshot auto` falls back to native directory/copy when an implicit WSL payload is unavailable
- explicit WSL overrides and required btrfs fail closed on missing or incompatible binaries

## Verification

- `go test ./... -count=1 -timeout 4m` (frontend/cli-go)
- `go test ./internal/enginebin -cover -count=1` — 96.5%
- `node scripts/e2e-release/release-local-workflow.test.mjs`
- `node --check scripts/release-local.mjs`
- `git diff --check`