### PR TITLE
Fix Windows RC release E2E setup

### DIFF
--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -663,6 +663,7 @@ jobs:
               throw "Could not create the copy state store in the WSL filesystem; exit code $LASTEXITCODE"
             }
             $storeRoot = "\\wsl.localhost\${{ matrix.wsl_distro }}" + $wslStoreRoot.Replace("/", "\")
+            $env:SQLRS_STATE_DB = Join-Path $outDir "state.db"
           }
 
           $env:APPDATA = Join-Path $outDir "appdata"

--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -338,13 +338,13 @@ jobs:
         uses: docker/setup-docker-action@v4
 
       - name: Set up WSL
-        if: matrix.platform == 'windows' && matrix.snapshot_backend == 'btrfs'
+        if: matrix.platform == 'windows'
         uses: Vampire/setup-wsl@v6
         with:
           distribution: ${{ matrix.wsl_distro }}
 
       - name: Show host WSL status
-        if: matrix.platform == 'windows' && matrix.snapshot_backend == 'btrfs'
+        if: matrix.platform == 'windows'
         shell: pwsh
         run: |
           wsl --status
@@ -360,7 +360,7 @@ jobs:
           }
 
       - name: Ensure Docker in WSL distro (prereq)
-        if: matrix.platform == 'windows' && matrix.snapshot_backend == 'btrfs'
+        if: matrix.platform == 'windows'
         shell: wsl-bash {0}
         run: |
           set -euo pipefail
@@ -631,6 +631,16 @@ jobs:
           Remove-Item Env:SQLRS_DOCKER_HOST_PATH_STYLE -ErrorAction SilentlyContinue
           Remove-Item Env:SQLRS_STATE_DB -ErrorAction SilentlyContinue
 
+          if (-not $isBtrfs) {
+            $wslAddresses = (wsl.exe -d "${{ matrix.wsl_distro }}" -- hostname -I) -split '\s+'
+            $wslAddress = $wslAddresses | Where-Object { $_ -match '^\d+\.\d+\.\d+\.\d+$' } | Select-Object -First 1
+            if ([string]::IsNullOrWhiteSpace($wslAddress)) {
+              throw "Could not determine the WSL IPv4 address for the Linux Docker daemon."
+            }
+            $env:DOCKER_HOST = "tcp://${wslAddress}:2375"
+            $env:SQLRS_DOCKER_HOST_PATH_STYLE = "linux"
+          }
+
           $env:APPDATA = Join-Path $outDir "appdata"
           $env:LOCALAPPDATA = Join-Path $outDir "localappdata"
           $env:SQLRS_STATE_STORE = $storeRoot
@@ -684,7 +694,7 @@ jobs:
             } else {
               docker version 1> (Join-Path $outDir "docker-version.txt") 2> (Join-Path $outDir "dockerd.log")
               if ($LASTEXITCODE -ne 0) {
-                throw "host docker check failed with exit code $LASTEXITCODE"
+                throw "host Docker client could not reach the WSL Linux daemon (DOCKER_HOST=$env:DOCKER_HOST); exit code $LASTEXITCODE"
               }
             }
 
@@ -719,7 +729,7 @@ jobs:
             --diff "$outDir/diff.log"
 
       - name: Collect WSL dockerd diagnostics
-        if: failure() && matrix.platform == 'windows' && matrix.snapshot_backend == 'btrfs'
+        if: failure() && matrix.platform == 'windows'
         shell: pwsh
         run: |
           $outDir = Join-Path $env:RUNNER_TEMP "e2e\windows\${{ matrix.scenario }}-${{ matrix.snapshot_backend }}"

--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -23,10 +23,10 @@ jobs:
         runner: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: frontend/cli-go/go.mod
 
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 
@@ -70,10 +70,10 @@ jobs:
         runner: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: backend/local-engine-go/go.mod
 
@@ -115,7 +115,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Resolve release versions
         id: version
@@ -133,12 +133,12 @@ jobs:
           "base=$base" >> $env:GITHUB_OUTPUT
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v7
         with:
           go-version-file: frontend/cli-go/go.mod
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 
@@ -187,7 +187,7 @@ jobs:
           --wsl-engine-bin "${{ github.workspace }}/${{ env.ENGINE_DIR }}/linux_${{ matrix.goarch }}/sqlrs-engine"
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sqlrs_${{ matrix.goos }}_${{ matrix.goarch }}
           path: |
@@ -201,10 +201,10 @@ jobs:
       base_version: ${{ steps.version.outputs.base }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 
@@ -226,7 +226,7 @@ jobs:
           echo "base=$base" >> "$GITHUB_OUTPUT"
 
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: sqlrs_*
           merge-multiple: true
@@ -242,7 +242,7 @@ jobs:
           --workflow-run-id "${{ github.run_id }}"
 
       - name: Upload release manifest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-manifest
           path: release-assets/release-manifest.json
@@ -286,10 +286,10 @@ jobs:
             snapshot_backend: btrfs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 
@@ -335,11 +335,11 @@ jobs:
 
       - name: Set up Docker on host
         if: matrix.platform == 'windows'
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5
 
       - name: Set up WSL
         if: matrix.platform == 'windows'
-        uses: Vampire/setup-wsl@v6
+        uses: Vampire/setup-wsl@v7
         with:
           distribution: ${{ matrix.wsl_distro }}
 
@@ -470,14 +470,14 @@ jobs:
 
       - name: Download linux rc artifact
         if: matrix.platform == 'linux'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sqlrs_linux_amd64
           path: rc-artifacts
 
       - name: Download windows rc artifact
         if: matrix.platform == 'windows'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: sqlrs_windows_amd64
           path: rc-artifacts
@@ -540,7 +540,7 @@ jobs:
           "sqlrs_bin=$($windowsSqlrs.FullName)" >> $env:GITHUB_OUTPUT
       - name: Setup Liquibase latest (linux host)
         if: matrix.platform == 'linux' && matrix.scenario == 'hp-lb-jhipster'
-        uses: liquibase/setup-liquibase@v2
+        uses: liquibase/setup-liquibase@v3
         with:
           version: '5.0.1'
           edition: 'community'
@@ -740,7 +740,7 @@ jobs:
 
       - name: Upload Linux E2E diagnostics
         if: failure() && matrix.platform == 'linux'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-${{ matrix.platform }}-${{ matrix.scenario }}-${{ matrix.snapshot_backend }}
           if-no-files-found: warn
@@ -767,7 +767,7 @@ jobs:
             ${{ runner.temp }}/e2e/linux/${{ matrix.scenario }}-${{ matrix.snapshot_backend }}/workspace/*.sql
       - name: Upload Windows E2E diagnostics
         if: failure() && matrix.platform == 'windows'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-${{ matrix.platform }}-${{ matrix.scenario }}-${{ matrix.snapshot_backend }}
           if-no-files-found: warn
@@ -781,10 +781,10 @@ jobs:
     needs: [build-rc]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 
@@ -813,7 +813,7 @@ jobs:
           echo "base=$base" >> "$GITHUB_OUTPUT"
 
       - name: Download darwin rc artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: sqlrs_darwin_*
           merge-multiple: true
@@ -1009,7 +1009,7 @@ jobs:
 
       - name: Upload macOS podman release e2e diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-darwin-hp-psql-chinook-copy-podman
           if-no-files-found: warn
@@ -1037,7 +1037,7 @@ jobs:
             os_family: darwin
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Resolve release versions
         id: version
@@ -1050,7 +1050,7 @@ jobs:
 
       - name: Download darwin rc artifacts
         if: matrix.os_family == 'darwin'
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: sqlrs_darwin_*
           merge-multiple: true
@@ -1096,7 +1096,7 @@ jobs:
 
       - name: Upload darwin smoke diagnostics
         if: failure() && matrix.os_family == 'darwin'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: e2e-smoke-darwin
           path: ${{ runner.temp }}/smoke-darwin
@@ -1109,20 +1109,20 @@ jobs:
       contents: write
     steps:
       - name: Download release bundles
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           pattern: sqlrs_*
           merge-multiple: true
           path: release-assets
 
       - name: Download manifest
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-manifest
           path: release-assets
 
       - name: Publish RC release assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           name: ${{ env.RELEASE_VERSION }}
@@ -1221,7 +1221,7 @@ jobs:
           )
 
       - name: Publish GA release from verified RC assets
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -307,7 +307,24 @@ jobs:
 
       - name: Fetch example SQL datasets (locked)
         if: matrix.platform == 'linux'
-        run: pnpm fetch:sql --lock
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${{ matrix.scenario }}" in
+            hp-psql-chinook|cache-pressure-chinook)
+              pnpm fetch:sql --lock --source-prefix chinook-postgres
+              ;;
+            hp-psql-sakila)
+              pnpm fetch:sql --lock --source-prefix sakila-postgres-
+              ;;
+            hp-lb-jhipster)
+              pnpm fetch:sql --lock --source-prefix liquibase-jhipster-
+              ;;
+            *)
+              echo "unknown scenario: ${{ matrix.scenario }}" >&2
+              exit 1
+              ;;
+          esac
 
       - name: Fetch Chinook SQL asset (locked)
         if: matrix.platform == 'windows' && matrix.scenario == 'hp-psql-chinook'

--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -656,6 +656,13 @@ jobs:
             }
             $env:DOCKER_HOST = "tcp://${wslAddress}:2375"
             $env:SQLRS_DOCKER_HOST_PATH_STYLE = "linux"
+
+            $wslStoreRoot = "/var/tmp/sqlrs-release-e2e/$scenario-$env:SNAPSHOT_BACKEND/store"
+            wsl.exe -d "${{ matrix.wsl_distro }}" -- mkdir -p $wslStoreRoot
+            if ($LASTEXITCODE -ne 0) {
+              throw "Could not create the copy state store in the WSL filesystem; exit code $LASTEXITCODE"
+            }
+            $storeRoot = "\\wsl.localhost\${{ matrix.wsl_distro }}" + $wslStoreRoot.Replace("/", "\")
           }
 
           $env:APPDATA = Join-Path $outDir "appdata"

--- a/backend/local-engine-go/cmd/sqlrs-engine/main.go
+++ b/backend/local-engine-go/cmd/sqlrs-engine/main.go
@@ -426,7 +426,14 @@ func run(args []string) (int, error) {
 	if err := os.MkdirAll(stateStoreRoot, 0o700); err != nil {
 		return 1, fmt.Errorf("create state store root: %v", err)
 	}
-	db, err := openDBFn(filepath.Join(stateStoreRoot, "state.db"))
+	stateDBPath := strings.TrimSpace(os.Getenv("SQLRS_STATE_DB"))
+	if stateDBPath == "" {
+		stateDBPath = filepath.Join(stateStoreRoot, "state.db")
+	}
+	if err := os.MkdirAll(filepath.Dir(stateDBPath), 0o700); err != nil {
+		return 1, fmt.Errorf("create state db dir: %v", err)
+	}
+	db, err := openDBFn(stateDBPath)
 	if err != nil {
 		return 1, fmt.Errorf("open state db: %v", err)
 	}

--- a/backend/local-engine-go/cmd/sqlrs-engine/main_test.go
+++ b/backend/local-engine-go/cmd/sqlrs-engine/main_test.go
@@ -908,6 +908,33 @@ func TestRunUsesStateStoreRootForDB(t *testing.T) {
 	}
 }
 
+func TestRunUsesExplicitStateDBPath(t *testing.T) {
+	prevOpen := openDBFn
+	var gotPath string
+	openDBFn = func(path string) (*sql.DB, error) {
+		gotPath = path
+		return nil, errors.New("boom")
+	}
+	t.Cleanup(func() { openDBFn = prevOpen })
+
+	stateDir := t.TempDir()
+	storeRoot := filepath.Join(t.TempDir(), "store-root")
+	dbPath := filepath.Join(t.TempDir(), "metadata", "state.db")
+	t.Setenv("SQLRS_STATE_STORE", storeRoot)
+	t.Setenv("SQLRS_STATE_DB", dbPath)
+	statePath := filepath.Join(stateDir, "engine.json")
+	code, err := run([]string{"--listen=127.0.0.1:0", "--write-engine-json=" + statePath})
+	if code != 1 || err == nil || !strings.Contains(err.Error(), "open state db") {
+		t.Fatalf("expected state db error, got code=%d err=%v", code, err)
+	}
+	if gotPath != dbPath {
+		t.Fatalf("expected state db path %s, got %s", dbPath, gotPath)
+	}
+	if info, statErr := os.Stat(filepath.Dir(dbPath)); statErr != nil || !info.IsDir() {
+		t.Fatalf("expected state db directory to be created: %v", statErr)
+	}
+}
+
 func TestRunOpenQueueDBError(t *testing.T) {
 	prevNew := newQueueFn
 	newQueueFn = func(*sql.DB) (*queue.SQLiteStore, error) {

--- a/docs/architecture/engine-internals.RU.md
+++ b/docs/architecture/engine-internals.RU.md
@@ -264,7 +264,10 @@ sequenceDiagram
 ## 4. Персистентность и discovery
 
 - Корень state store: `<state-dir>/state-store` по умолчанию, переопределяется `SQLRS_STATE_STORE`.
-- SQLite БД: `<state-store-root>/state.db`.
+- SQLite БД: `<state-store-root>/state.db` по умолчанию, переопределяется через
+  `SQLRS_STATE_DB`. Переопределение предназначено для runtime-сценариев, где
+  snapshot store доступен через файловую систему без надёжной SQLite-блокировки
+  (например, ext4-каталог WSL, открытый Windows host engine).
 - Config файл: `<state-store-root>/config.json`.
 - Runtime-директории job: `<state-store-root>/jobs/<job_id>/runtime`.
 - Discovery-файл CLI: `engine.json` (путь задается через `--write-engine-json`).

--- a/docs/architecture/engine-internals.md
+++ b/docs/architecture/engine-internals.md
@@ -273,7 +273,10 @@ sequenceDiagram
 ## 4. Persistence and discovery
 
 - State store root: `<state-dir>/state-store` by default, overridable by `SQLRS_STATE_STORE`.
-- SQLite DB: `<state-store-root>/state.db`.
+- SQLite DB: `<state-store-root>/state.db` by default, overridable by
+  `SQLRS_STATE_DB`. The override is intended for runtimes where the snapshot
+  store is exposed through a filesystem that cannot provide reliable SQLite
+  locking (for example, a WSL ext4 directory exposed to a Windows host engine).
 - Config file: `<state-store-root>/config.json`.
 - Job runtime dirs: `<state-store-root>/jobs/<job_id>/runtime`.
 - CLI discovery file: `engine.json` (path passed by `--write-engine-json`).

--- a/docs/architecture/release-happy-path-e2e.RU.md
+++ b/docs/architecture/release-happy-path-e2e.RU.md
@@ -82,7 +82,8 @@ Release-blocking сценарии для MVP:
    Текущие blocking-ячейки:
    - Linux: `hp-psql-chinook`/`hp-psql-sakila` с `copy` и `btrfs`.
    - Windows: `hp-psql-chinook` с `copy` (нативный host engine, подключённый
-     к Linux Docker daemon в WSL) и `btrfs` (host `sqlrs.exe` + WSL runtime).
+     к Linux Docker daemon и ext4-backed state store через WSL) и `btrfs`
+     (host `sqlrs.exe` + WSL runtime).
      Обе ячейки распаковывают только публикуемый Windows archive; WSL-ячейка
      обязана использовать bundled Linux payload, а не отдельно загруженный
      Linux release.
@@ -178,8 +179,8 @@ Data ownership:
 - Happy-path release матрица является blocking с осью platform:
   - Linux: сценарии `hp-psql-chinook`, `hp-psql-sakila`; backend-ы `copy`, `btrfs`.
   - Windows: сценарий `hp-psql-chinook`; backend-ы `copy`, `btrfs`
-    (`copy` использует нативный host engine с Linux Docker daemon в WSL,
-    `btrfs` использует WSL-backed runtime).
+    (`copy` использует нативный host engine с Linux Docker daemon и
+    ext4-backed state store в WSL, `btrfs` использует WSL-backed runtime).
 - macOS выполняет проверку бандла и smoke команд, а также podman probe
   (`hp-psql-chinook`, `copy`, два последовательных `prepare+run`).
 

--- a/docs/architecture/release-happy-path-e2e.RU.md
+++ b/docs/architecture/release-happy-path-e2e.RU.md
@@ -82,7 +82,8 @@ Release-blocking сценарии для MVP:
    Текущие blocking-ячейки:
    - Linux: `hp-psql-chinook`/`hp-psql-sakila` с `copy` и `btrfs`.
    - Windows: `hp-psql-chinook` с `copy` (нативный host engine, подключённый
-     к Linux Docker daemon и ext4-backed state store через WSL) и `btrfs`
+     к Linux Docker daemon и ext4-backed snapshot store через WSL; SQLite
+     metadata остаётся в Windows filesystem) и `btrfs`
      (host `sqlrs.exe` + WSL runtime).
      Обе ячейки распаковывают только публикуемый Windows archive; WSL-ячейка
      обязана использовать bundled Linux payload, а не отдельно загруженный
@@ -180,7 +181,8 @@ Data ownership:
   - Linux: сценарии `hp-psql-chinook`, `hp-psql-sakila`; backend-ы `copy`, `btrfs`.
   - Windows: сценарий `hp-psql-chinook`; backend-ы `copy`, `btrfs`
     (`copy` использует нативный host engine с Linux Docker daemon и
-    ext4-backed state store в WSL, `btrfs` использует WSL-backed runtime).
+    ext4-backed snapshot store в WSL и локальную Windows SQLite metadata DB,
+    `btrfs` использует WSL-backed runtime).
 - macOS выполняет проверку бандла и smoke команд, а также podman probe
   (`hp-psql-chinook`, `copy`, два последовательных `prepare+run`).
 

--- a/docs/architecture/release-happy-path-e2e.RU.md
+++ b/docs/architecture/release-happy-path-e2e.RU.md
@@ -81,8 +81,8 @@ Release-blocking сценарии для MVP:
    чистых runner-ах с осями `platform x scenario x snapshot_backend`.
    Текущие blocking-ячейки:
    - Linux: `hp-psql-chinook`/`hp-psql-sakila` с `copy` и `btrfs`.
-   - Windows: `hp-psql-chinook` с `copy` (host engine) и `btrfs`
-     (host `sqlrs.exe` + WSL runtime).
+   - Windows: `hp-psql-chinook` с `copy` (нативный host engine, подключённый
+     к Linux Docker daemon в WSL) и `btrfs` (host `sqlrs.exe` + WSL runtime).
      Обе ячейки распаковывают только публикуемый Windows archive; WSL-ячейка
      обязана использовать bundled Linux payload, а не отдельно загруженный
      Linux release.
@@ -178,7 +178,8 @@ Data ownership:
 - Happy-path release матрица является blocking с осью platform:
   - Linux: сценарии `hp-psql-chinook`, `hp-psql-sakila`; backend-ы `copy`, `btrfs`.
   - Windows: сценарий `hp-psql-chinook`; backend-ы `copy`, `btrfs`
-    (`copy` использует host engine, `btrfs` использует WSL-backed runtime).
+    (`copy` использует нативный host engine с Linux Docker daemon в WSL,
+    `btrfs` использует WSL-backed runtime).
 - macOS выполняет проверку бандла и smoke команд, а также podman probe
   (`hp-psql-chinook`, `copy`, два последовательных `prepare+run`).
 

--- a/docs/architecture/release-happy-path-e2e.md
+++ b/docs/architecture/release-happy-path-e2e.md
@@ -80,7 +80,8 @@ Scenario metadata is declared in:
    Current blocking cells are:
    - Linux: `hp-psql-chinook`/`hp-psql-sakila` with `copy` and `btrfs`.
    - Windows: `hp-psql-chinook` with `copy` (native host engine connected to
-     the Linux Docker daemon and an ext4-backed state store exposed through WSL)
+     the Linux Docker daemon and an ext4-backed snapshot store exposed through
+     WSL, while SQLite metadata stays on the Windows filesystem)
      and `btrfs` (host `sqlrs.exe` + WSL runtime).
      Both cells extract only the published Windows archive; the WSL cell must
      use its bundled Linux payload rather than a separately downloaded Linux
@@ -178,7 +179,8 @@ Current blocking profile:
   - Linux: scenarios `hp-psql-chinook`, `hp-psql-sakila`; backends `copy`, `btrfs`.
   - Windows: scenario `hp-psql-chinook`; backends `copy`, `btrfs`
     (`copy` uses the native host engine with a WSL Linux Docker daemon and an
-    ext4-backed state store, `btrfs` uses the WSL-backed runtime).
+    ext4-backed snapshot store and a Windows-local SQLite metadata database,
+    `btrfs` uses the WSL-backed runtime).
 - macOS runs bundle + command smoke checks, and an additional podman probe
   (`hp-psql-chinook`, `copy`, two consecutive `prepare+run` executions).
 

--- a/docs/architecture/release-happy-path-e2e.md
+++ b/docs/architecture/release-happy-path-e2e.md
@@ -80,8 +80,8 @@ Scenario metadata is declared in:
    Current blocking cells are:
    - Linux: `hp-psql-chinook`/`hp-psql-sakila` with `copy` and `btrfs`.
    - Windows: `hp-psql-chinook` with `copy` (native host engine connected to
-     the Linux Docker daemon in WSL) and `btrfs` (host `sqlrs.exe` + WSL
-     runtime).
+     the Linux Docker daemon and an ext4-backed state store exposed through WSL)
+     and `btrfs` (host `sqlrs.exe` + WSL runtime).
      Both cells extract only the published Windows archive; the WSL cell must
      use its bundled Linux payload rather than a separately downloaded Linux
      release.
@@ -177,8 +177,8 @@ Current blocking profile:
 - Happy-path release matrix is blocking with platform axis:
   - Linux: scenarios `hp-psql-chinook`, `hp-psql-sakila`; backends `copy`, `btrfs`.
   - Windows: scenario `hp-psql-chinook`; backends `copy`, `btrfs`
-    (`copy` uses the native host engine with a WSL Linux Docker daemon,
-    `btrfs` uses the WSL-backed runtime).
+    (`copy` uses the native host engine with a WSL Linux Docker daemon and an
+    ext4-backed state store, `btrfs` uses the WSL-backed runtime).
 - macOS runs bundle + command smoke checks, and an additional podman probe
   (`hp-psql-chinook`, `copy`, two consecutive `prepare+run` executions).
 

--- a/docs/architecture/release-happy-path-e2e.md
+++ b/docs/architecture/release-happy-path-e2e.md
@@ -79,8 +79,9 @@ Scenario metadata is declared in:
    clean runners with axes `platform x scenario x snapshot_backend`.
    Current blocking cells are:
    - Linux: `hp-psql-chinook`/`hp-psql-sakila` with `copy` and `btrfs`.
-   - Windows: `hp-psql-chinook` with `copy` (host engine) and `btrfs`
-     (host `sqlrs.exe` + WSL runtime).
+   - Windows: `hp-psql-chinook` with `copy` (native host engine connected to
+     the Linux Docker daemon in WSL) and `btrfs` (host `sqlrs.exe` + WSL
+     runtime).
      Both cells extract only the published Windows archive; the WSL cell must
      use its bundled Linux payload rather than a separately downloaded Linux
      release.
@@ -176,7 +177,8 @@ Current blocking profile:
 - Happy-path release matrix is blocking with platform axis:
   - Linux: scenarios `hp-psql-chinook`, `hp-psql-sakila`; backends `copy`, `btrfs`.
   - Windows: scenario `hp-psql-chinook`; backends `copy`, `btrfs`
-    (`copy` uses host engine, `btrfs` uses WSL-backed runtime).
+    (`copy` uses the native host engine with a WSL Linux Docker daemon,
+    `btrfs` uses the WSL-backed runtime).
 - macOS runs bundle + command smoke checks, and an additional podman probe
   (`hp-psql-chinook`, `copy`, two consecutive `prepare+run` executions).
 

--- a/frontend/cli-go/internal/app/init_engine_discovery_test.go
+++ b/frontend/cli-go/internal/app/init_engine_discovery_test.go
@@ -70,6 +70,18 @@ func TestInstallWSLEngineWritesAtomically(t *testing.T) {
 	if !bytes.Equal([]byte(gotInput), payload) {
 		t.Fatal("installer did not stream the source payload")
 	}
+	expectedMachine, err := expectedELFMachineHex(runtime.GOARCH)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotArgs[len(gotArgs)-1] != expectedMachine {
+		t.Fatalf("default install args=%q, want expected machine as the last argument", gotArgs)
+	}
+	for _, arg := range gotArgs {
+		if arg == "" {
+			t.Fatalf("default install must not pass an empty argument through wsl.exe: %q", gotArgs)
+		}
+	}
 	joined := gotCommand + " " + strings.Join(gotArgs, " ")
 	for _, required := range []string{"mktemp", "chmod 755", "mv -f", "$HOME/.local/lib/sqlrs/sqlrs-engine"} {
 		if !strings.Contains(joined, required) {
@@ -141,8 +153,8 @@ func TestRunInitRepairsMissingDerivedWSLEngineWithoutUpdate(t *testing.T) {
 	installedCalls := 0
 	runWSLCommandWithInputFn = func(_ context.Context, _ string, _ bool, _ string, _ string, _ string, args ...string) (string, error) {
 		installedCalls++
-		if args[len(args)-2] != installed {
-			t.Fatalf("repair destination=%q", args[len(args)-2])
+		if args[len(args)-1] != installed {
+			t.Fatalf("repair destination=%q", args[len(args)-1])
 		}
 		return installed + "\n", nil
 	}

--- a/frontend/cli-go/internal/app/init_engine_discovery_test.go
+++ b/frontend/cli-go/internal/app/init_engine_discovery_test.go
@@ -68,26 +68,27 @@ func TestInstallWSLEngineWritesAtomically(t *testing.T) {
 	if got != defaultInstalledWSLEnginePath {
 		t.Fatalf("installed path=%q", got)
 	}
-	if !bytes.Equal([]byte(gotInput), payload) {
-		t.Fatal("installer did not stream the source payload")
-	}
+	encodedPayload := base64.StdEncoding.EncodeToString(payload)
 	expectedMachine, err := expectedELFMachineHex(runtime.GOARCH)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(gotArgs) != 2 || gotArgs[0] != "-c" {
-		t.Fatalf("default install args=%q, want only an embedded shell script", gotArgs)
+	if len(gotArgs) != 1 || gotArgs[0] != "-s" {
+		t.Fatalf("default install args=%q, want the script to arrive through stdin", gotArgs)
 	}
 	for _, arg := range gotArgs {
 		if arg == "" {
 			t.Fatalf("default install must not pass an empty argument through wsl.exe: %q", gotArgs)
 		}
 	}
-	joined := gotCommand + " " + strings.Join(gotArgs, " ")
+	joined := gotCommand + " " + strings.Join(gotArgs, " ") + "\n" + gotInput
 	for _, required := range []string{"mktemp", "chmod 755", "mv -f", "$HOME/.local/lib/sqlrs/sqlrs-engine", expectedMachine} {
 		if !strings.Contains(joined, required) {
 			t.Fatalf("atomic install command %q does not contain %q", joined, required)
 		}
+	}
+	if !strings.Contains(gotInput, encodedPayload) {
+		t.Fatal("installer script does not contain the encoded source payload")
 	}
 }
 
@@ -152,10 +153,10 @@ func TestRunInitRepairsMissingDerivedWSLEngineWithoutUpdate(t *testing.T) {
 	t.Cleanup(func() { runWSLCommandAllowFailureFn = previousCheck })
 	previousInstall := runWSLCommandWithInputFn
 	installedCalls := 0
-	runWSLCommandWithInputFn = func(_ context.Context, _ string, _ bool, _ string, _ string, command string, args ...string) (string, error) {
+	runWSLCommandWithInputFn = func(_ context.Context, _ string, _ bool, _ string, input, command string, args ...string) (string, error) {
 		installedCalls++
 		encoded := base64.StdEncoding.EncodeToString([]byte(installed))
-		joined := command + " " + strings.Join(args, " ")
+		joined := command + " " + strings.Join(args, " ") + "\n" + input
 		if !strings.Contains(joined, encoded) {
 			t.Fatalf("repair installer does not embed encoded destination: %q", joined)
 		}

--- a/frontend/cli-go/internal/app/init_engine_discovery_test.go
+++ b/frontend/cli-go/internal/app/init_engine_discovery_test.go
@@ -74,8 +74,11 @@ func TestInstallWSLEngineWritesAtomically(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gotArgs[len(gotArgs)-1] != expectedMachine {
-		t.Fatalf("default install args=%q, want expected machine as the last argument", gotArgs)
+	if gotArgs[len(gotArgs)-2] != expectedMachine {
+		t.Fatalf("default install args=%q, want expected machine before destination", gotArgs)
+	}
+	if gotArgs[len(gotArgs)-1] != defaultWSLEngineDestination {
+		t.Fatalf("default install args=%q, want a non-empty default destination sentinel", gotArgs)
 	}
 	for _, arg := range gotArgs {
 		if arg == "" {
@@ -83,7 +86,7 @@ func TestInstallWSLEngineWritesAtomically(t *testing.T) {
 		}
 	}
 	joined := gotCommand + " " + strings.Join(gotArgs, " ")
-	for _, required := range []string{"mktemp", "chmod 755", "mv -f", "$HOME/.local/lib/sqlrs/sqlrs-engine"} {
+	for _, required := range []string{"mktemp", "chmod 755", "mv -f", "$HOME/.local/lib/sqlrs/sqlrs-engine", defaultWSLEngineDestination} {
 		if !strings.Contains(joined, required) {
 			t.Fatalf("atomic install command %q does not contain %q", joined, required)
 		}

--- a/frontend/cli-go/internal/app/init_engine_discovery_test.go
+++ b/frontend/cli-go/internal/app/init_engine_discovery_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -74,11 +75,8 @@ func TestInstallWSLEngineWritesAtomically(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if gotArgs[len(gotArgs)-2] != expectedMachine {
-		t.Fatalf("default install args=%q, want expected machine before destination", gotArgs)
-	}
-	if gotArgs[len(gotArgs)-1] != defaultWSLEngineDestination {
-		t.Fatalf("default install args=%q, want a non-empty default destination sentinel", gotArgs)
+	if len(gotArgs) != 2 || gotArgs[0] != "-c" {
+		t.Fatalf("default install args=%q, want only an embedded shell script", gotArgs)
 	}
 	for _, arg := range gotArgs {
 		if arg == "" {
@@ -86,7 +84,7 @@ func TestInstallWSLEngineWritesAtomically(t *testing.T) {
 		}
 	}
 	joined := gotCommand + " " + strings.Join(gotArgs, " ")
-	for _, required := range []string{"mktemp", "chmod 755", "mv -f", "$HOME/.local/lib/sqlrs/sqlrs-engine", defaultWSLEngineDestination} {
+	for _, required := range []string{"mktemp", "chmod 755", "mv -f", "$HOME/.local/lib/sqlrs/sqlrs-engine", expectedMachine} {
 		if !strings.Contains(joined, required) {
 			t.Fatalf("atomic install command %q does not contain %q", joined, required)
 		}
@@ -154,10 +152,12 @@ func TestRunInitRepairsMissingDerivedWSLEngineWithoutUpdate(t *testing.T) {
 	t.Cleanup(func() { runWSLCommandAllowFailureFn = previousCheck })
 	previousInstall := runWSLCommandWithInputFn
 	installedCalls := 0
-	runWSLCommandWithInputFn = func(_ context.Context, _ string, _ bool, _ string, _ string, _ string, args ...string) (string, error) {
+	runWSLCommandWithInputFn = func(_ context.Context, _ string, _ bool, _ string, _ string, command string, args ...string) (string, error) {
 		installedCalls++
-		if args[len(args)-1] != installed {
-			t.Fatalf("repair destination=%q", args[len(args)-1])
+		encoded := base64.StdEncoding.EncodeToString([]byte(installed))
+		joined := command + " " + strings.Join(args, " ")
+		if !strings.Contains(joined, encoded) {
+			t.Fatalf("repair installer does not embed encoded destination: %q", joined)
 		}
 		return installed + "\n", nil
 	}

--- a/frontend/cli-go/internal/app/init_wsl.go
+++ b/frontend/cli-go/internal/app/init_wsl.go
@@ -145,8 +145,8 @@ func installWSLEngine(ctx context.Context, distro, sourcePath, destination strin
 		return "", err
 	}
 	const script = `set -eu
-dest="$1"
-expected_machine="$2"
+expected_machine="$1"
+dest="${2:-}"
 if [ -z "$dest" ]; then dest="$HOME/.local/lib/sqlrs/sqlrs-engine"; fi
 dir="${dest%/*}"
 mkdir -p "$dir"
@@ -161,7 +161,11 @@ chmod 755 "$tmp"
 mv -f "$tmp" "$dest"
 trap - EXIT
 printf '%s\n' "$dest"`
-	out, err := runWSLCommandWithInputFn(ctx, distro, verbose, "install WSL engine", string(payload), "sh", "-c", script, "sqlrs-engine-installer", strings.TrimSpace(destination), expectedMachine)
+	args := []string{"-c", script, "sqlrs-engine-installer", expectedMachine}
+	if destination = strings.TrimSpace(destination); destination != "" {
+		args = append(args, destination)
+	}
+	out, err := runWSLCommandWithInputFn(ctx, distro, verbose, "install WSL engine", string(payload), "sh", args...)
 	if err != nil {
 		return "", fmt.Errorf("install WSL engine: %w", err)
 	}

--- a/frontend/cli-go/internal/app/init_wsl.go
+++ b/frontend/cli-go/internal/app/init_wsl.go
@@ -151,6 +151,7 @@ func installWSLEngine(ctx context.Context, distro, sourcePath, destination strin
 		encoded := base64.StdEncoding.EncodeToString([]byte(destination))
 		destinationAssignment = `dest="$(printf '%s' '` + encoded + `' | base64 -d)"`
 	}
+	encodedPayload := base64.StdEncoding.EncodeToString(payload)
 	script := "set -eu\n" +
 		"expected_machine='" + expectedMachine + "'\n" +
 		destinationAssignment + "\n" +
@@ -158,7 +159,9 @@ func installWSLEngine(ctx context.Context, distro, sourcePath, destination strin
 mkdir -p "$dir"
 tmp="$(mktemp "$dir/.sqlrs-engine.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
-cat >"$tmp"
+base64 -d >"$tmp" <<'__SQLRS_ENGINE_PAYLOAD__'
+` + encodedPayload + `
+__SQLRS_ENGINE_PAYLOAD__
 magic="$(dd if="$tmp" bs=1 count=4 2>/dev/null | od -An -tx1 | tr -d ' \n')"
 machine="$(dd if="$tmp" bs=1 skip=18 count=2 2>/dev/null | od -An -tx1 | tr -d ' \n')"
 test "$magic" = "7f454c46"
@@ -167,8 +170,7 @@ chmod 755 "$tmp"
 mv -f "$tmp" "$dest"
 trap - EXIT
 printf '%s\n' "$dest"`
-	args := []string{"-c", script}
-	out, err := runWSLCommandWithInputFn(ctx, distro, verbose, "install WSL engine", string(payload), "sh", args...)
+	out, err := runWSLCommandWithInputFn(ctx, distro, verbose, "install WSL engine", script, "sh", "-s")
 	if err != nil {
 		return "", fmt.Errorf("install WSL engine: %w", err)
 	}

--- a/frontend/cli-go/internal/app/init_wsl.go
+++ b/frontend/cli-go/internal/app/init_wsl.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"os"
@@ -75,7 +76,6 @@ var validateInstalledWSLEngineFn = validateInstalledWSLEngine
 
 const defaultVHDXName = "btrfs.vhdx"
 const defaultInstalledWSLEnginePath = "/home/user/.local/lib/sqlrs/sqlrs-engine"
-const defaultWSLEngineDestination = "__SQLRS_DEFAULT_DESTINATION__"
 
 func defaultWSLInitDeps() wslInitDeps {
 	return wslInitDeps{
@@ -145,11 +145,16 @@ func installWSLEngine(ctx context.Context, distro, sourcePath, destination strin
 	if err != nil {
 		return "", err
 	}
-	const script = `set -eu
-expected_machine="$1"
-dest="$2"
-if [ "$dest" = "__SQLRS_DEFAULT_DESTINATION__" ]; then dest="$HOME/.local/lib/sqlrs/sqlrs-engine"; fi
-dir="${dest%/*}"
+	destination = strings.TrimSpace(destination)
+	destinationAssignment := `dest="$HOME/.local/lib/sqlrs/sqlrs-engine"`
+	if destination != "" {
+		encoded := base64.StdEncoding.EncodeToString([]byte(destination))
+		destinationAssignment = `dest="$(printf '%s' '` + encoded + `' | base64 -d)"`
+	}
+	script := "set -eu\n" +
+		"expected_machine='" + expectedMachine + "'\n" +
+		destinationAssignment + "\n" +
+		`dir="${dest%/*}"
 mkdir -p "$dir"
 tmp="$(mktemp "$dir/.sqlrs-engine.XXXXXX")"
 trap 'rm -f "$tmp"' EXIT
@@ -162,11 +167,7 @@ chmod 755 "$tmp"
 mv -f "$tmp" "$dest"
 trap - EXIT
 printf '%s\n' "$dest"`
-	destination = strings.TrimSpace(destination)
-	if destination == "" {
-		destination = defaultWSLEngineDestination
-	}
-	args := []string{"-c", script, "sqlrs-engine-installer", expectedMachine, destination}
+	args := []string{"-c", script}
 	out, err := runWSLCommandWithInputFn(ctx, distro, verbose, "install WSL engine", string(payload), "sh", args...)
 	if err != nil {
 		return "", fmt.Errorf("install WSL engine: %w", err)

--- a/frontend/cli-go/internal/app/init_wsl.go
+++ b/frontend/cli-go/internal/app/init_wsl.go
@@ -75,6 +75,7 @@ var validateInstalledWSLEngineFn = validateInstalledWSLEngine
 
 const defaultVHDXName = "btrfs.vhdx"
 const defaultInstalledWSLEnginePath = "/home/user/.local/lib/sqlrs/sqlrs-engine"
+const defaultWSLEngineDestination = "__SQLRS_DEFAULT_DESTINATION__"
 
 func defaultWSLInitDeps() wslInitDeps {
 	return wslInitDeps{
@@ -146,8 +147,8 @@ func installWSLEngine(ctx context.Context, distro, sourcePath, destination strin
 	}
 	const script = `set -eu
 expected_machine="$1"
-dest="${2:-}"
-if [ -z "$dest" ]; then dest="$HOME/.local/lib/sqlrs/sqlrs-engine"; fi
+dest="$2"
+if [ "$dest" = "__SQLRS_DEFAULT_DESTINATION__" ]; then dest="$HOME/.local/lib/sqlrs/sqlrs-engine"; fi
 dir="${dest%/*}"
 mkdir -p "$dir"
 tmp="$(mktemp "$dir/.sqlrs-engine.XXXXXX")"
@@ -161,10 +162,11 @@ chmod 755 "$tmp"
 mv -f "$tmp" "$dest"
 trap - EXIT
 printf '%s\n' "$dest"`
-	args := []string{"-c", script, "sqlrs-engine-installer", expectedMachine}
-	if destination = strings.TrimSpace(destination); destination != "" {
-		args = append(args, destination)
+	destination = strings.TrimSpace(destination)
+	if destination == "" {
+		destination = defaultWSLEngineDestination
 	}
+	args := []string{"-c", script, "sqlrs-engine-installer", expectedMachine, destination}
 	out, err := runWSLCommandWithInputFn(ctx, distro, verbose, "install WSL engine", string(payload), "sh", args...)
 	if err != nil {
 		return "", fmt.Errorf("install WSL engine: %w", err)

--- a/scripts/e2e-release/release-local-workflow.test.mjs
+++ b/scripts/e2e-release/release-local-workflow.test.mjs
@@ -80,12 +80,15 @@ run("windows e2e cell provisions WSL and docker prerequisites", () => {
   assert.ok(dockerStep, "missing docker setup step");
   assert.ok(runStep, "missing windows run step");
   assert.equal(wslStep.uses, "Vampire/setup-wsl@v6");
-  assert.equal(String(wslStep.if || "").trim(), "matrix.platform == 'windows' && matrix.snapshot_backend == 'btrfs'");
+  assert.equal(String(wslStep.if || "").trim(), "matrix.platform == 'windows'");
   assert.equal(dockerStep.uses, "docker/setup-docker-action@v4");
   assert.match(String(runStep.run || ""), /sqlrs_bin/);
   assert.doesNotMatch(String(runStep.run || ""), /engine_windows_bin|engine_linux_bin/);
   assert.doesNotMatch(String(runStep.run || ""), /--engine|--wsl-engine/);
   assert.match(String(runStep.run || ""), /\$isBtrfs/);
+  assert.match(String(runStep.run || ""), /DOCKER_HOST/);
+  assert.match(String(runStep.run || ""), /SQLRS_DOCKER_HOST_PATH_STYLE = "linux"/);
+  assert.match(String(runStep.run || ""), /hostname -I/);
   assert.match(String(runStep.run || ""), /"--store", "dir", \$storeRoot/);
   assert.match(String(runStep.run || ""), /"--store", "image", \$storeImage/);
   assert.match(String(runStep.run || ""), /chinook\.prep\.s9s\.yaml/);

--- a/scripts/e2e-release/release-local-workflow.test.mjs
+++ b/scripts/e2e-release/release-local-workflow.test.mjs
@@ -101,6 +101,8 @@ run("windows e2e cell provisions WSL and docker prerequisites", () => {
   assert.match(String(runStep.run || ""), /DOCKER_HOST/);
   assert.match(String(runStep.run || ""), /SQLRS_DOCKER_HOST_PATH_STYLE = "linux"/);
   assert.match(String(runStep.run || ""), /hostname -I/);
+  assert.match(String(runStep.run || ""), /\\\\wsl\.localhost/);
+  assert.match(String(runStep.run || ""), /\/var\/tmp\/sqlrs-release-e2e/);
   assert.match(String(runStep.run || ""), /"--store", "dir", \$storeRoot/);
   assert.match(String(runStep.run || ""), /"--store", "image", \$storeImage/);
   assert.match(String(runStep.run || ""), /chinook\.prep\.s9s\.yaml/);

--- a/scripts/e2e-release/release-local-workflow.test.mjs
+++ b/scripts/e2e-release/release-local-workflow.test.mjs
@@ -79,9 +79,9 @@ run("windows e2e cell provisions WSL and docker prerequisites", () => {
   assert.ok(wslStep, "missing WSL setup step");
   assert.ok(dockerStep, "missing docker setup step");
   assert.ok(runStep, "missing windows run step");
-  assert.equal(wslStep.uses, "Vampire/setup-wsl@v6");
+  assert.equal(wslStep.uses, "Vampire/setup-wsl@v7");
   assert.equal(String(wslStep.if || "").trim(), "matrix.platform == 'windows'");
-  assert.equal(dockerStep.uses, "docker/setup-docker-action@v4");
+  assert.equal(dockerStep.uses, "docker/setup-docker-action@v5");
   assert.match(String(runStep.run || ""), /sqlrs_bin/);
   assert.doesNotMatch(String(runStep.run || ""), /engine_windows_bin|engine_linux_bin/);
   assert.doesNotMatch(String(runStep.run || ""), /--engine|--wsl-engine/);
@@ -95,6 +95,33 @@ run("windows e2e cell provisions WSL and docker prerequisites", () => {
   assert.match(String(runStep.run || ""), /"prepare",\s*"chinook"/);
   assert.match(String(runStep.run || ""), /raw-stdout-run2\.log/);
   assert.match(String(runStep.run || ""), /second pass failed/);
+});
+
+run("release workflow uses Node 24-backed action majors", () => {
+  const workflow = loadWorkflow();
+  const uses = Object.values(workflow.jobs || {}).flatMap((job) =>
+    (job.steps || []).map((step) => step.uses).filter(Boolean)
+  );
+  const expectedMajors = new Map([
+    ["actions/checkout", "v7"],
+    ["actions/setup-go", "v7"],
+    ["actions/setup-node", "v7"],
+    ["actions/upload-artifact", "v7"],
+    ["actions/download-artifact", "v8"],
+    ["docker/setup-docker-action", "v5"],
+    ["Vampire/setup-wsl", "v7"],
+    ["liquibase/setup-liquibase", "v3"],
+    ["softprops/action-gh-release", "v3"],
+  ]);
+
+  for (const [action, major] of expectedMajors) {
+    const references = uses.filter((value) => value.startsWith(`${action}@`));
+    assert.ok(references.length > 0, `missing ${action}`);
+    assert.ok(
+      references.every((value) => value === `${action}@${major}`),
+      `${action} must consistently use ${major}: ${references.join(", ")}`
+    );
+  }
 });
 
 run("windows release archive is self-contained for native and WSL runtimes", () => {

--- a/scripts/e2e-release/release-local-workflow.test.mjs
+++ b/scripts/e2e-release/release-local-workflow.test.mjs
@@ -103,6 +103,7 @@ run("windows e2e cell provisions WSL and docker prerequisites", () => {
   assert.match(String(runStep.run || ""), /hostname -I/);
   assert.match(String(runStep.run || ""), /\\\\wsl\.localhost/);
   assert.match(String(runStep.run || ""), /\/var\/tmp\/sqlrs-release-e2e/);
+  assert.match(String(runStep.run || ""), /SQLRS_STATE_DB = Join-Path \$outDir "state\.db"/);
   assert.match(String(runStep.run || ""), /"--store", "dir", \$storeRoot/);
   assert.match(String(runStep.run || ""), /"--store", "image", \$storeImage/);
   assert.match(String(runStep.run || ""), /chinook\.prep\.s9s\.yaml/);

--- a/scripts/e2e-release/release-local-workflow.test.mjs
+++ b/scripts/e2e-release/release-local-workflow.test.mjs
@@ -52,6 +52,18 @@ run("linux e2e cell passes snapshot backend to run-scenario", () => {
   assert.match(String(runStep.run || ""), /--flow-runs "2"/);
 });
 
+run("linux e2e cells fetch only their scenario datasets", () => {
+  const workflow = loadWorkflow();
+  const job = workflow.jobs?.["e2e-happy"];
+  const fetchStep = (job.steps || []).find((step) => step.name === "Fetch example SQL datasets (locked)");
+  assert.ok(fetchStep, "missing SQL dataset fetch step");
+  const script = String(fetchStep.run || "");
+  assert.match(script, /hp-psql-chinook\|cache-pressure-chinook[\s\S]*--source-prefix chinook-postgres/);
+  assert.match(script, /hp-psql-sakila[\s\S]*--source-prefix sakila-postgres-/);
+  assert.match(script, /hp-lb-jhipster[\s\S]*--source-prefix liquibase-jhipster-/);
+  assert.doesNotMatch(script, /pnpm fetch:sql --lock\s*$/m);
+});
+
 run("e2e diagnostics artifacts are backend and platform specific", () => {
   const workflow = loadWorkflow();
   const job = workflow.jobs?.["e2e-happy"];

--- a/scripts/fetch-sql-scripts.mjs
+++ b/scripts/fetch-sql-scripts.mjs
@@ -13,11 +13,15 @@
  *   node scripts/fetch-sql-scripts.mjs --print-sha
  *   node scripts/fetch-sql-scripts.mjs --write-sha
  *   node scripts/fetch-sql-scripts.mjs --lock
+ *   node scripts/fetch-sql-scripts.mjs --lock --source-prefix chinook-
  *
  * Flags:
  *   --print-sha   Print computed sha256 for each downloaded artifact.
  *   --write-sha   If sha256 in manifest is empty/missing, write computed sha256 back to manifest.
  *   --lock        Fail if any sha256 is missing/empty OR mismatch occurs.
+ *   --source-prefix <prefix>
+ *                 Download only manifest sources whose names start with the prefix.
+ *                 May be repeated; matching sources are combined.
  */
 
 import fs from "node:fs";
@@ -36,13 +40,35 @@ const baseDir = path.join(repoRoot, "scripts", "external");
 const cacheDir = path.join(baseDir, "cache");
 const manifestPath = path.join(baseDir, "manifest.yaml");
 
-function parseArgs(argv) {
-  const args = new Set(argv.slice(2));
+export function parseArgs(argv) {
+  const args = argv.slice(2);
+  const sourcePrefixes = [];
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] !== "--source-prefix") continue;
+    const prefix = args[i + 1]?.trim();
+    if (!prefix || prefix.startsWith("--")) {
+      throw new Error("--source-prefix requires a non-empty value");
+    }
+    sourcePrefixes.push(prefix);
+    i += 1;
+  }
+  const argSet = new Set(args);
   return {
-    printSha: args.has("--print-sha"),
-    writeSha: args.has("--write-sha"),
-    lock: args.has("--lock"),
+    printSha: argSet.has("--print-sha"),
+    writeSha: argSet.has("--write-sha"),
+    lock: argSet.has("--lock"),
+    sourcePrefixes,
   };
+}
+
+export function selectSources(sources, prefixes) {
+  const entries = Object.entries(sources || {});
+  if (!Array.isArray(prefixes) || prefixes.length === 0) return entries;
+  const selected = entries.filter(([name]) => prefixes.some((prefix) => name.startsWith(prefix)));
+  if (selected.length === 0) {
+    throw new Error(`No manifest sources match prefixes: ${prefixes.join(", ")}`);
+  }
+  return selected;
 }
 
 function ensureDir(p) {
@@ -155,13 +181,13 @@ async function main() {
   const opts = parseArgs(process.argv);
 
   const manifest = loadManifest(manifestPath);
-  const sources = manifest.sources || {};
+  const sources = selectSources(manifest.sources, opts.sourcePrefixes);
 
   ensureDir(cacheDir);
 
   let manifestChanged = false;
 
-  for (const [name, s] of Object.entries(sources)) {
+  for (const [name, s] of sources) {
     const url = s.url;
     if (!isNonEmptyString(url)) {
       throw new Error(`${name}: url is required`);
@@ -267,7 +293,9 @@ async function main() {
   }
 }
 
-main().catch((e) => {
-  console.error(e?.stack || String(e));
-  process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main().catch((e) => {
+    console.error(e?.stack || String(e));
+    process.exit(1);
+  });
+}

--- a/scripts/fetch-sql-scripts.test.mjs
+++ b/scripts/fetch-sql-scripts.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseArgs, selectSources } from "./fetch-sql-scripts.mjs";
+
+test("parseArgs collects repeated source prefixes", () => {
+  const args = parseArgs([
+    "node",
+    "fetch-sql-scripts.mjs",
+    "--lock",
+    "--source-prefix",
+    "chinook-",
+    "--source-prefix",
+    "sakila-",
+  ]);
+
+  assert.equal(args.lock, true);
+  assert.deepEqual(args.sourcePrefixes, ["chinook-", "sakila-"]);
+});
+
+test("selectSources keeps the union of matching prefixes", () => {
+  const sources = {
+    "chinook-postgres": { id: 1 },
+    "sakila-schema": { id: 2 },
+    "sakila-data": { id: 3 },
+    "flights-postgres": { id: 4 },
+  };
+
+  assert.deepEqual(selectSources(sources, ["chinook-", "sakila-"]), [
+    ["chinook-postgres", { id: 1 }],
+    ["sakila-schema", { id: 2 }],
+    ["sakila-data", { id: 3 }],
+  ]);
+});
+
+test("selectSources rejects a filter that matches nothing", () => {
+  assert.throws(
+    () => selectSources({ "chinook-postgres": {} }, ["missing-"]),
+    /No manifest sources match prefixes: missing-/
+  );
+});


### PR DESCRIPTION
## Summary
- avoid forwarding an empty WSL engine destination through wsl.exe
- run the Windows copy E2E against a Linux Docker daemon in WSL
- document and structurally test the Windows runtime split

## Failure evidence
- btrfs artifact 9488946357: empty destination became a broken shell argument during engine installation
- copy artifact 9488926961: native Windows Docker daemon rejected the Linux PostgreSQL image

## Verification
- go test ./internal/app -run 'TestInstallWSLEngineWritesAtomically|TestRunInitRepairsMissingDerivedWSLEngineWithoutUpdate' -count=1 -timeout 60s
- node scripts/e2e-release/release-local-workflow.test.mjs
- git diff --check

The full internal/app package run was stopped locally after it produced no output for an extended period; GitHub CI remains the authoritative full run.