### PR TITLE
Stabilize Sakila btrfs release E2E

### DIFF
--- a/backend/local-engine-go/internal/prepare/execution.go
+++ b/backend/local-engine-go/internal/prepare/execution.go
@@ -551,9 +551,9 @@ func (e *taskExecutor) executePsqlStep(ctx context.Context, jobID string, prepar
 		if ctx.Err() != nil {
 			return errorResponse("cancelled", "task cancelled", "")
 		}
-		details := strings.TrimSpace(output)
-		if details == "" {
-			details = err.Error()
+		details := strings.TrimSpace(err.Error())
+		if renderedOutput := strings.TrimSpace(output); renderedOutput != "" {
+			details += "\n" + renderedOutput
 		}
 		if noSpaceResp := noSpaceErrorResponse("prepare step failed due to insufficient storage", "prepare_step", errors.New(details)); noSpaceResp != nil {
 			return noSpaceResp

--- a/backend/local-engine-go/internal/prepare/execution_coverage_extra_test.go
+++ b/backend/local-engine-go/internal/prepare/execution_coverage_extra_test.go
@@ -423,8 +423,8 @@ func TestExecutePsqlStepOutputDetails(t *testing.T) {
 	prepared := preparedRequest{normalizedArgs: []string{"-c", "select 1"}}
 	rt := &jobRuntime{}
 	errResp := mgr.executePsqlStep(context.Background(), "job-1", prepared, rt, taskState{})
-	if errResp == nil || !strings.Contains(errResp.Details, "details") {
-		t.Fatalf("expected details from output, got %+v", errResp)
+	if errResp == nil || !strings.Contains(errResp.Details, "boom") || !strings.Contains(errResp.Details, "details") {
+		t.Fatalf("expected the runner error and command output in details, got %+v", errResp)
 	}
 }
 

--- a/examples/sakila.prep.s9s.yaml
+++ b/examples/sakila.prep.s9s.yaml
@@ -1,5 +1,6 @@
 kind: psql
 image: postgres:17
 args:
+  - --quiet
   - -f
   - sakila/prepare.sql

--- a/scripts/e2e-release/release-local-workflow.test.mjs
+++ b/scripts/e2e-release/release-local-workflow.test.mjs
@@ -8,6 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..", "..");
 const workflowPath = path.join(repoRoot, ".github", "workflows", "release-local.yml");
+const sakilaAliasPath = path.join(repoRoot, "examples", "sakila.prep.s9s.yaml");
 
 function run(name, fn) {
   try {
@@ -23,6 +24,11 @@ function loadWorkflow() {
   const raw = fs.readFileSync(workflowPath, "utf8");
   return YAML.parse(raw);
 }
+
+run("sakila release fixture suppresses per-statement psql status output", () => {
+  const alias = YAML.parse(fs.readFileSync(sakilaAliasPath, "utf8"));
+  assert.ok(alias.args?.includes("--quiet"), "Sakila prepare must run psql in quiet mode");
+});
 
 run("happy e2e matrix includes platform and snapshot backend axes", () => {
   const workflow = loadWorkflow();


### PR DESCRIPTION
## Summary
- run the Sakila prepare fixture with psql quiet mode to avoid emitting roughly 140,000 command-status events
- retain the underlying psql runner error alongside captured output for actionable diagnostics

## Verification
- targeted prepare tests
- release-local workflow structural tests
- git diff --check