### PR TITLE
Embed RC tag in release binaries

### DIFF
--- a/.github/workflows/release-local.yml
+++ b/.github/workflows/release-local.yml
@@ -125,6 +125,9 @@ jobs:
           if ([string]::IsNullOrWhiteSpace($raw)) {
             throw "release version is empty"
           }
+          if ($raw -notmatch '^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$') {
+            throw "release version must match vMAJOR.MINOR.PATCH-rc.NUMBER"
+          }
           $base = $raw -replace '-rc\.[0-9]+$',''
           if ([string]::IsNullOrWhiteSpace($base)) {
             throw "base version is empty"
@@ -148,7 +151,8 @@ jobs:
         run: |
           mkdir -p "${{ github.workspace }}/${{ env.ENGINE_DIR }}/${{ matrix.goos }}_${{ matrix.goarch }}"
           GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} CGO_ENABLED=0 \
-            go build -o "${{ github.workspace }}/${{ env.ENGINE_DIR }}/${{ matrix.goos }}_${{ matrix.goarch }}/sqlrs-engine${{ matrix.exe }}" \
+            go build -ldflags "-X main.buildVersion=${{ steps.version.outputs.raw }}" \
+            -o "${{ github.workspace }}/${{ env.ENGINE_DIR }}/${{ matrix.goos }}_${{ matrix.goarch }}/sqlrs-engine${{ matrix.exe }}" \
             ./cmd/sqlrs-engine
 
       - name: Build engine (windows)
@@ -160,18 +164,20 @@ jobs:
           $env:GOOS = "${{ matrix.goos }}"
           $env:GOARCH = "${{ matrix.goarch }}"
           $env:CGO_ENABLED = "0"
-          go build -o "$outDir\\sqlrs-engine${{ matrix.exe }}" ./cmd/sqlrs-engine
+          $ldflags = "-X main.buildVersion=${{ steps.version.outputs.raw }}"
+          go build -ldflags $ldflags -o "$outDir\\sqlrs-engine${{ matrix.exe }}" ./cmd/sqlrs-engine
 
           $linuxOutDir = "${{ github.workspace }}\\${{ env.ENGINE_DIR }}\\linux_${{ matrix.goarch }}"
           New-Item -ItemType Directory -Force -Path $linuxOutDir | Out-Null
           $env:GOOS = "linux"
-          go build -o "$linuxOutDir\\sqlrs-engine" ./cmd/sqlrs-engine
+          go build -ldflags $ldflags -o "$linuxOutDir\\sqlrs-engine" ./cmd/sqlrs-engine
 
       - name: Build local release (unix)
         if: runner.os != 'Windows'
         run: >
           node scripts/release-local.mjs
           --version "${{ steps.version.outputs.base }}"
+          --build-version "${{ steps.version.outputs.raw }}"
           --os "${{ matrix.goos }}"
           --arch "${{ matrix.goarch }}"
           --engine-bin "${{ github.workspace }}/${{ env.ENGINE_DIR }}/${{ matrix.goos }}_${{ matrix.goarch }}/sqlrs-engine${{ matrix.exe }}"
@@ -181,6 +187,7 @@ jobs:
         run: >
           node scripts/release-local.mjs
           --version "${{ steps.version.outputs.base }}"
+          --build-version "${{ steps.version.outputs.raw }}"
           --os "${{ matrix.goos }}"
           --arch "${{ matrix.goarch }}"
           --engine-bin "${{ github.workspace }}/${{ env.ENGINE_DIR }}/${{ matrix.goos }}_${{ matrix.goarch }}/sqlrs-engine${{ matrix.exe }}"

--- a/backend/local-engine-go/cmd/sqlrs-engine/main.go
+++ b/backend/local-engine-go/cmd/sqlrs-engine/main.go
@@ -364,6 +364,9 @@ var serverShutdownFn = func(server *http.Server, ctx context.Context) error {
 var isCharDeviceFn = isCharDevice
 var jsonMarshalIndent = json.MarshalIndent
 
+// buildVersion is injected by the release workflow. Development builds keep the explicit dev value.
+var buildVersion = "dev"
+
 func run(args []string) (int, error) {
 	fs := flag.NewFlagSet("sqlrs-engine", flag.ContinueOnError)
 	fs.SetOutput(io.Discard)
@@ -372,7 +375,7 @@ func run(args []string) (int, error) {
 	runDir := fs.String("run-dir", "", "runtime directory (unused in MVP)")
 	statePath := fs.String("write-engine-json", "", "path to engine.json")
 	idleTimeout := fs.Duration("idle-timeout", 30*time.Second, "shutdown after this idle duration")
-	version := fs.String("version", "dev", "engine version")
+	version := fs.String("version", buildVersion, "engine version")
 	if err := fs.Parse(args); err != nil {
 		return 2, err
 	}

--- a/docs/architecture/release-happy-path-e2e.RU.md
+++ b/docs/architecture/release-happy-path-e2e.RU.md
@@ -40,6 +40,11 @@
 - архив: `sqlrs_<version>_<os>_<arch>.<ext>`
 - checksum: `sqlrs_<version>_<os>_<arch>.<ext>.sha256`
 
+В имени архива используется базовая версия (`vX.Y.Z`). И `sqlrs`, и каждый
+payload `sqlrs-engine` содержат полный исходный release tag (`vX.Y.Z-rc.N`) и
+показывают его во время выполнения. Сборки вне release workflow сохраняют
+явную версию `dev`.
+
 Также нужен дополнительный manifest-артефакт:
 
 - `release-manifest.json` со списком таргетов, checksums, `workflow run id` и

--- a/docs/architecture/release-happy-path-e2e.md
+++ b/docs/architecture/release-happy-path-e2e.md
@@ -39,6 +39,11 @@ Per target, release output includes:
 - archive: `sqlrs_<version>_<os>_<arch>.<ext>`
 - checksum: `sqlrs_<version>_<os>_<arch>.<ext>.sha256`
 
+The archive name uses the base version (`vX.Y.Z`). Both `sqlrs` and every
+`sqlrs-engine` payload embed the full source release tag (`vX.Y.Z-rc.N`) and
+report it at runtime. Builds made outside the release workflow retain the
+explicit `dev` version.
+
 An additional manifest artifact is required:
 
 - `release-manifest.json` with target list, checksums, workflow run id,

--- a/docs/roadmap.RU.md
+++ b/docs/roadmap.RU.md
@@ -93,6 +93,8 @@ gantt
   для Chinook/Sakila с расширением матрицы (включая Btrfs), поведение
   `init --btrfs` выровнено между Linux и Windows, Windows WSL/docker probe
   встроен в release-проверки, усилена детерминированность output/workspace.
+- **Сделано (release identity)**: RC-бандлы содержат полный исходный tag в CLI,
+  native engine и встроенном WSL engine, а нерелизные сборки остаются `dev`.
 - **Сделано (MVP command surface)**: локальный MVP-набор команд стабилен вокруг
   `init/config/ls/status/plan/prepare/run/rm`; legacy-нейминг команд в
   документации считается устаревшим.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -92,6 +92,8 @@ gantt
   Chinook/Sakila with matrix expansion (incl. Btrfs), `init --btrfs` behaviour
   unified across Linux/Windows, Windows WSL/docker probe moved into release
   verification, and deterministic output/workspace handling was tightened.
+- **Done (release identity)**: RC bundles embed the full source tag in the CLI,
+  native engine, and bundled WSL engine while non-release builds remain `dev`.
 - **Done (MVP command surface)**: local MVP command set is stable around
   `init/config/ls/status/plan/prepare/run/rm`; legacy command naming is
   deprecated in docs.

--- a/scripts/e2e-release/release-local-workflow.test.mjs
+++ b/scripts/e2e-release/release-local-workflow.test.mjs
@@ -8,6 +8,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..", "..");
 const workflowPath = path.join(repoRoot, ".github", "workflows", "release-local.yml");
+const releaseScriptPath = path.join(repoRoot, "scripts", "release-local.mjs");
 const sakilaAliasPath = path.join(repoRoot, "examples", "sakila.prep.s9s.yaml");
 
 function run(name, fn) {
@@ -161,6 +162,26 @@ run("windows release archive is self-contained for native and WSL runtimes", () 
   const extract = (e2e.steps || []).find((step) => step.name === "Extract windows bundle");
   assert.match(String(extract?.run || ""), /libexec/);
   assert.match(String(extract?.run || ""), /linux-amd64/);
+});
+
+run("release binaries embed the full release candidate tag", () => {
+  const workflow = loadWorkflow();
+  const build = workflow.jobs?.["build-rc"];
+  const unixEngine = (build.steps || []).find((step) => step.name === "Build engine (unix)");
+  const windowsEngine = (build.steps || []).find((step) => step.name === "Build engine (windows)");
+  const unixRelease = (build.steps || []).find((step) => step.name === "Build local release (unix)");
+  const windowsRelease = (build.steps || []).find((step) => step.name === "Build local release (windows)");
+  const resolveVersion = (build.steps || []).find((step) => step.name === "Resolve release versions");
+
+  assert.match(String(resolveVersion?.run || ""), /vMAJOR\.MINOR\.PATCH-rc\.NUMBER/);
+  assert.match(String(unixEngine?.run || ""), /-X main\.buildVersion=\$\{\{ steps\.version\.outputs\.raw \}\}/);
+  assert.match(String(windowsEngine?.run || ""), /-X main\.buildVersion=\$\{\{ steps\.version\.outputs\.raw \}\}/);
+  assert.match(String(unixRelease?.run || ""), /--build-version "\$\{\{ steps\.version\.outputs\.raw \}\}"/);
+  assert.match(String(windowsRelease?.run || ""), /--build-version "\$\{\{ steps\.version\.outputs\.raw \}\}"/);
+
+  const releaseScript = fs.readFileSync(releaseScriptPath, "utf8");
+  assert.match(releaseScript, /args\["build-version"\] \|\| process\.env\.SQLRS_BUILD_VERSION \|\| version/);
+  assert.match(releaseScript, /-X github\.com\/sqlrs\/cli\/internal\/app\.Version=\$\{buildVersion\}/);
 });
 
 run("publish RC waits for unified e2e-happy job", () => {

--- a/scripts/release-local.mjs
+++ b/scripts/release-local.mjs
@@ -76,6 +76,7 @@ function copyDir(src, dest) {
 
 const args = parseArgs(process.argv.slice(2));
 const version = args.version || process.env.SQLRS_VERSION;
+const buildVersion = args["build-version"] || process.env.SQLRS_BUILD_VERSION || version;
 const goos = args.os || process.env.GOOS;
 const goarch = args.arch || process.env.GOARCH;
 const workspace = args.workspace ? path.resolve(args.workspace) : repoRoot;
@@ -118,7 +119,15 @@ const enginePath = path.resolve(engineBin);
 const wslEnginePath = wslEngineBin ? path.resolve(wslEngineBin) : "";
 
 await run({
-  cmd: ["go", "build", "-o", cliPath, "./cmd/sqlrs"],
+  cmd: [
+    "go",
+    "build",
+    "-ldflags",
+    `-X github.com/sqlrs/cli/internal/app.Version=${buildVersion}`,
+    "-o",
+    cliPath,
+    "./cmd/sqlrs"
+  ],
   cwd: cliRoot,
   env: { ...process.env, GOOS: goos, GOARCH: goarch, CGO_ENABLED: "0" }
 });


### PR DESCRIPTION
## Summary
- embed the full validated RC tag in sqlrs and every sqlrs-engine payload
- keep base-version archive names and dev metadata for non-release builds
- document the release identity invariant and cover it in the workflow contract test

## Verification
- release workflow contract test passed
- full CLI test suite passed
- engine cmd package tests passed with 96.0% statement coverage
- a temporary Windows bundle contained the test RC tag in sqlrs.exe, sqlrs-engine.exe, and the bundled Linux WSL engine