### PR TITLE
fix(cli): resolve run instance prefixes

### DIFF
--- a/docs/adr/2026-09-04-run-instance-prefix-resolution.md
+++ b/docs/adr/2026-09-04-run-instance-prefix-resolution.md
@@ -1,0 +1,28 @@
+# ADR: Run instance prefix resolution
+
+Status: Accepted
+Date: 2026-09-04
+
+## Decision Record 1
+
+- Timestamp: 2026-09-04T16:06:08+07:00
+- User: @evilguest
+- Agent: Codex (GPT-5)
+- Question: Where and in what order should `sqlrs run --instance` resolve an
+  instance ID prefix while preserving the existing full-ID and name behavior?
+- Alternatives:
+  - Resolve an eligible prefix in the CLI through the existing instance-list
+    `id_prefix` filter, then send the canonical full ID to `POST /v1/runs`.
+  - Extend `POST /v1/runs` so the engine run manager resolves prefixes.
+  - Extend `GET /v1/instances/{idOrName}` so path lookup accepts prefixes.
+  - List every instance in the CLI and filter locally.
+- Decision: The CLI preserves exact full-ID and exact-name matches first. If an
+  exact lookup misses and the value is a case-insensitive hexadecimal prefix of
+  at least 8 characters, the CLI resolves it through
+  `GET /v1/instances?id_prefix=...`. Exactly one match is converted to its full
+  instance ID before `POST /v1/runs`; zero matches fail as not found and
+  multiple matches fail as ambiguous.
+- Rationale: This implements issue #95 using the prefix-filter contract already
+  selected by [ADR 0007](0007-id-prefix-resolution.md), keeps exact-name
+  behavior backward compatible, avoids broadening path lookup or run API
+  semantics, and avoids unbounded client-side listing.

--- a/docs/architecture/cli-architecture.RU.md
+++ b/docs/architecture/cli-architecture.RU.md
@@ -177,11 +177,18 @@ sequenceDiagram
     CLI->>ENG: GET /v1/prepare-jobs/{jobId} (on status events)
     ENG-->>CLI: terminal status + DSN
   else Explicit instance
-    CLI->>ENG: resolve instance by id or name
-    ENG-->>CLI: instance_id + DSN
+    alt Значение в форме префикса (8+ hex-символов)
+      CLI->>ENG: GET /v1/instances/{idOrName}
+      ENG-->>CLI: точный instance или 404
+      opt Точное совпадение отсутствует
+        CLI->>ENG: GET /v1/instances?id_prefix={prefix}
+        ENG-->>CLI: ноль, один или несколько instances
+      end
+    end
+    CLI->>CLI: требует один instance и сохраняет его полный id
   end
 
-  CLI->>ENG: POST /v1/runs (kind, command or default, args)
+  CLI->>ENG: POST /v1/runs (полный instance id, kind, command or default, args)
   opt Missing instance container
     ENG-->>CLI: event "run: container missing - recreating"
     ENG-->>CLI: event "run: restoring runtime"
@@ -204,6 +211,10 @@ sequenceDiagram
   использует `-h/-p/-U/-d`.
 - Команды выполняются внутри контейнера инстанса (тот же runtime, что и
   `prepare:psql`).
+- Для явно заданного шестнадцатеричного `--instance` длиной 8+ символов CLI
+  сохраняет точное совпадение по id/name, а иначе разрешает значение через
+  существующий prefix filter списка instances. Ноль совпадений дает not-found,
+  несколько — ambiguity; `POST /v1/runs` получает канонический полный id.
 - Если контейнер инстанса отсутствует и `runtime_dir` существует, engine
   пересоздает контейнер и пишет run-события до выполнения команды.
 - Если `--instance` задан вместе с предыдущим `prepare`, CLI завершает работу с

--- a/docs/architecture/cli-architecture.md
+++ b/docs/architecture/cli-architecture.md
@@ -177,11 +177,18 @@ sequenceDiagram
     CLI->>ENG: GET /v1/prepare-jobs/{jobId} (on status events)
     ENG-->>CLI: terminal status + DSN
   else Explicit instance
-    CLI->>ENG: resolve instance by id or name
-    ENG-->>CLI: instance_id + DSN
+    alt Prefix-shaped value (8+ hex characters)
+      CLI->>ENG: GET /v1/instances/{idOrName}
+      ENG-->>CLI: exact instance or 404
+      opt Exact miss
+        CLI->>ENG: GET /v1/instances?id_prefix={prefix}
+        ENG-->>CLI: zero, one, or multiple instances
+      end
+    end
+    CLI->>CLI: require one instance and retain its full id
   end
 
-  CLI->>ENG: POST /v1/runs (kind, command or default, args)
+  CLI->>ENG: POST /v1/runs (full instance id, kind, command or default, args)
   opt Missing instance container
     ENG-->>CLI: event "run: container missing - recreating"
     ENG-->>CLI: event "run: restoring runtime"
@@ -203,6 +210,10 @@ Notes:
 - `run:psql` passes DSN as a positional connection string; `run:pgbench` uses
   `-h/-p/-U/-d`.
 - Commands run inside the instance container (same runtime as `prepare:psql`).
+- For an explicit 8+ character hexadecimal `--instance`, the CLI preserves an
+  exact id/name match, otherwise resolves the value through the existing
+  instance-list prefix filter. Zero matches fail as not found and multiple
+  matches fail as ambiguous; `POST /v1/runs` receives the canonical full id.
 - If the instance container is missing and `runtime_dir` exists, the engine
   recreates the container and emits run events before execution.
 - If `--instance` is provided together with a preceding `prepare`, the CLI fails

--- a/docs/architecture/cli-component-structure.RU.md
+++ b/docs/architecture/cli-component-structure.RU.md
@@ -83,6 +83,10 @@
   - Исполнители клиентских команд и human/JSON renderers, включая auth command
     rendering, read-only cache-explain rendering и rendering remote-only
     управления пользователями и организациями.
+  - Владеет канонизацией target для run: сохраняет точные совпадения id/name,
+    разрешает подходящие 8+ hex-префиксы через фильтр списка instances в
+    `internal/client`, отклоняет отсутствующие или неоднозначные совпадения и
+    передает полный instance id в run endpoint.
 - `internal/cli/runkind`
   - Реестр поддерживаемых run kind.
 - `internal/authsession`
@@ -196,6 +200,9 @@
 - Состояние discovery локального engine (`engine.json`, daemon lock/process
   metadata) ведется через `internal/daemon`.
 - Rendered alias-create commands эфемерны и существуют только в CLI output.
+- Run target, разрешенный из `--instance`, эфемерен в рамках одного invocation;
+  CLI сохраняет только канонический полный instance id в исходящем run request
+  и не персистит результаты resolution.
 - Server config принадлежит engine-side storage и читается/изменяется по HTTP
   (`/v1/config*`), без локального кеширования в CLI.
 - Профили пользователей, external identities, организации и memberships

--- a/docs/architecture/cli-component-structure.md
+++ b/docs/architecture/cli-component-structure.md
@@ -81,6 +81,10 @@ addition of a shared `inputset` layer for file-bearing command semantics.
   - Client-side command executors and human/JSON renderers, including
     auth command rendering, read-only cache-explain rendering, and remote-only
     user/organization management rendering.
+  - Owns run target canonicalization: preserve exact id/name matches, resolve
+    eligible 8+ hex prefixes through `internal/client` instance-list filtering,
+    reject ambiguous or missing matches, and send a full instance id to the run
+    endpoint.
 - `internal/cli/runkind`
   - Registry of supported run kinds.
 - `internal/authsession`
@@ -192,6 +196,9 @@ addition of a shared `inputset` layer for file-bearing command semantics.
 - Engine discovery state (`engine.json`, daemon lock/process metadata) is
   managed via `internal/daemon`.
 - Rendered alias-create commands are ephemeral and exist only in CLI output.
+- A run target resolved from `--instance` is ephemeral for one invocation; the
+  CLI retains only the canonical full instance id in the outgoing run request
+  and does not persist resolution results.
 - Server config is owned by engine-side storage and accessed via HTTP
   (`/v1/config*`), not cached by the CLI.
 - User profiles, external identities, organizations, and memberships are owned

--- a/docs/architecture/cli-contract.RU.md
+++ b/docs/architecture/cli-contract.RU.md
@@ -269,9 +269,13 @@ CLI должен предоставлять `plan:<kind>` для каждого 
 
 Текущее поведение:
 
-- standalone `sqlrs run <run-ref> --instance <id|name>` резолвит repo-tracked
+- standalone `sqlrs run <run-ref> --instance <id|id-prefix|name>` резолвит repo-tracked
   `*.run.s9s.yaml` file от текущего рабочего каталога, сохраняя явный выбор
   runtime instance;
+- значения `--instance` в форме префикса сохраняют точные совпадения id/name,
+  а иначе разрешаются через `GET /v1/instances?id_prefix=...`; run request
+  получает единственный полный instance id, а ноль или несколько совпадений
+  приводят к ошибке;
 - bounded client-side `run --ref <git-ref>` поддерживает local и remote
   profiles для single-stage `run`; он применяется к alias-backed
   `run <run-ref>` и raw `run:psql` / `run:pgbench`, проецируя caller cwd в

--- a/docs/architecture/cli-contract.md
+++ b/docs/architecture/cli-contract.md
@@ -277,9 +277,12 @@ Implemented ref-aware flow and component documents:
 
 Current behavior:
 
-- standalone `sqlrs run <run-ref> --instance <id|name>` resolves a repo-tracked
+- standalone `sqlrs run <run-ref> --instance <id|id-prefix|name>` resolves a repo-tracked
   `*.run.s9s.yaml` file from the current working directory while keeping runtime
   instance selection explicit;
+- prefix-shaped `--instance` values preserve exact id/name matches, otherwise
+  resolve through `GET /v1/instances?id_prefix=...`; the run request receives
+  the unique full instance id, while zero or multiple matches fail;
 - bounded client-side `run --ref <git-ref>` supports local and remote profiles
   for single-stage `run`; it applies to alias-backed `run <run-ref>` and raw
   `run:psql` / `run:pgbench`, projecting the caller cwd into the selected ref

--- a/docs/architecture/m2-local-developer-experience-plan.RU.md
+++ b/docs/architecture/m2-local-developer-experience-plan.RU.md
@@ -101,7 +101,7 @@ local workspace config.
 
 **Основной результат**:
 
-- standalone `sqlrs run <run-ref> --instance <id|name>` резолвит
+- standalone `sqlrs run <run-ref> --instance <id|id-prefix|name>` резолвит
   `<run-ref>.run.s9s.yaml` от текущего рабочего каталога
 - `prepare ... run ...` принимает смешанные raw/alias комбинации
 - `sqlrs alias ls [--prepare] [--run] [--from <workspace|cwd|path>] [--depth <self|children|recursive>]`

--- a/docs/architecture/m2-local-developer-experience-plan.md
+++ b/docs/architecture/m2-local-developer-experience-plan.md
@@ -101,7 +101,7 @@ local workspace config.
 
 **Primary outcome**:
 
-- standalone `sqlrs run <run-ref> --instance <id|name>` resolves
+- standalone `sqlrs run <run-ref> --instance <id|id-prefix|name>` resolves
   `<run-ref>.run.s9s.yaml` from the current working directory
 - `prepare ... run ...` accepts mixed raw/alias combinations
 - `sqlrs alias ls [--prepare] [--run] [--from <workspace|cwd|path>] [--depth <self|children|recursive>]`

--- a/docs/roadmap.RU.md
+++ b/docs/roadmap.RU.md
@@ -113,6 +113,12 @@ gantt
   `*.run.s9s.yaml` files, с exact-file escape через trailing `.`, cwd-relative
   alias-ref resolution, alias-file-relative file-bearing paths и смешанной raw
   и alias-композицией `prepare ... run` с guardrails вокруг `--instance`.
+- **Сделано ([#95](https://github.com/kimak-irmagi/sqlrs/issues/95), разрешение
+  префикса instance для run)**: standalone raw, alias и ref-backed команды
+  `run` принимают регистронезависимые шестнадцатеричные префиксы instance ID
+  длиной 8+ символов. CLI сохраняет точные совпадения ID/name, отклоняет
+  отсутствующие или неоднозначные префиксы и отправляет канонический полный
+  instance ID в run endpoint.
 - **Сделано (M2 alias inspection baseline)**: CLI теперь включает
   `sqlrs alias ls` и `sqlrs alias check [<ref>]` с ограниченной scan scope,
   дефолтом `cwd + recursive`, явными `--from` / `--depth`, статической

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -112,6 +112,11 @@ gantt
   `*.run.s9s.yaml` files, with exact-file escape via trailing `.`, cwd-relative
   alias-ref resolution, alias-file-relative file-bearing paths, and mixed raw
   and alias `prepare ... run` composition with `--instance` guardrails.
+- **Done ([#95](https://github.com/kimak-irmagi/sqlrs/issues/95), run instance
+  prefix resolution)**: standalone raw, alias, and ref-backed `run` commands
+  accept case-insensitive 8+ character hexadecimal instance ID prefixes. The
+  CLI preserves exact ID/name matches, rejects missing or ambiguous prefixes,
+  and sends the canonical full instance ID to the run endpoint.
 - **Done (M2 alias inspection baseline)**: the CLI now ships
   `sqlrs alias ls` and `sqlrs alias check [<ref>]` with bounded scan scope,
   default `cwd + recursive`, explicit `--from` / `--depth` controls, static

--- a/docs/user-guides/sqlrs-aliases.md
+++ b/docs/user-guides/sqlrs-aliases.md
@@ -9,7 +9,7 @@ Current local CLI support includes:
 
 - `sqlrs plan <prepare-ref>`
 - `sqlrs prepare <prepare-ref>`
-- `sqlrs run <run-ref> [--instance <id|name>]`
+- `sqlrs run <run-ref> [--instance <id|id-prefix|name>]`
 - `*.prep.s9s.yaml` prepare alias files
 - `*.run.s9s.yaml` run alias files
 - exact-file escape via a trailing `.`
@@ -102,7 +102,7 @@ Resolution rule:
 ### Run resolution
 
 ```text
-sqlrs run <ref> [--instance <id|name>]
+sqlrs run <ref> [--instance <id|id-prefix|name>]
 ```
 
 Resolution rule:
@@ -168,7 +168,7 @@ Alias mode uses the bare verb plus an alias ref as the subject:
 ```text
 sqlrs plan <prepare-ref>
 sqlrs prepare <prepare-ref>
-sqlrs run <run-ref> [--instance <id|name>]
+sqlrs run <run-ref> [--instance <id|id-prefix|name>]
 ```
 
 Examples:
@@ -201,9 +201,9 @@ freely:
 
 ```text
 sqlrs prepare <prepare-ref> run <run-ref>
-sqlrs prepare <prepare-ref> run:<kind> [--instance <id|name>] [-- <command>] [args...]
+sqlrs prepare <prepare-ref> run:<kind> [--instance <id|id-prefix|name>] [-- <command>] [args...]
 sqlrs prepare:<kind> ... run <run-ref>
-sqlrs prepare:<kind> ... run:<kind> [--instance <id|name>] [-- <command>] [args...]
+sqlrs prepare:<kind> ... run:<kind> [--instance <id|id-prefix|name>] [-- <command>] [args...]
 ```
 
 Examples:

--- a/docs/user-guides/sqlrs-prepare.md
+++ b/docs/user-guides/sqlrs-prepare.md
@@ -73,9 +73,9 @@ Current boundaries:
 
 ```text
 sqlrs prepare <prepare-ref> run <run-ref>
-sqlrs prepare <prepare-ref> run:<kind> [--instance <id|name>] [-- <command>] [args...]
+sqlrs prepare <prepare-ref> run:<kind> [--instance <id|id-prefix|name>] [-- <command>] [args...]
 sqlrs prepare:<kind> [--watch|--no-watch] [--image <image-id>] [--] [tool-args...] run <run-ref>
-sqlrs prepare:<kind> [--watch|--no-watch] [--image <image-id>] [--] [tool-args...] run:<kind> [--instance <id|name>] [-- <command>] [args...]
+sqlrs prepare:<kind> [--watch|--no-watch] [--image <image-id>] [--] [tool-args...] run:<kind> [--instance <id|id-prefix|name>] [-- <command>] [args...]
 ```
 
 Rules:

--- a/docs/user-guides/sqlrs-run-ref.md
+++ b/docs/user-guides/sqlrs-run-ref.md
@@ -31,8 +31,8 @@ out of scope.
 Public syntax:
 
 ```text
-sqlrs run [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] <run-ref> --instance <id|name>
-sqlrs run:<kind> [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] [--instance <id|name>] [-- <command>] [args...]
+sqlrs run [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] <run-ref> --instance <id|id-prefix|name>
+sqlrs run:<kind> [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] [--instance <id|id-prefix|name>] [-- <command>] [args...]
 ```
 
 Selection rules:
@@ -42,7 +42,7 @@ Selection rules:
 - `--ref-mode` and `--ref-keep-worktree` are valid only when `--ref` is set;
 - `--ref-mode` defaults to `worktree`;
 - `--ref-keep-worktree` is valid only with `--ref-mode worktree`;
-- standalone alias mode still requires `--instance <id|name>`;
+- standalone alias mode still requires `--instance <id|id-prefix|name>`;
 - `run --ref` is standalone only.
 
 The flag belongs to the `run` stage itself, not to global CLI options.
@@ -53,11 +53,11 @@ The flag belongs to the `run` stage itself, not to global CLI options.
 
 ### Supported
 
-- `sqlrs run --ref <ref> <run-alias> --instance <id|name>`
-- `sqlrs run:psql --ref <ref> --instance <id|name> -- -f ...`
-- `sqlrs run:psql --ref <ref> --instance <id|name> -- -c ...`
-- `sqlrs run:pgbench --ref <ref> --instance <id|name> -- -f ...`
-- `sqlrs run:pgbench --ref <ref> --instance <id|name> -- -c ...`
+- `sqlrs run --ref <ref> <run-alias> --instance <id|id-prefix|name>`
+- `sqlrs run:psql --ref <ref> --instance <id|id-prefix|name> -- -f ...`
+- `sqlrs run:psql --ref <ref> --instance <id|id-prefix|name> -- -c ...`
+- `sqlrs run:pgbench --ref <ref> --instance <id|id-prefix|name> -- -f ...`
+- `sqlrs run:pgbench --ref <ref> --instance <id|id-prefix|name> -- -c ...`
 
 These shapes work with local and remote profiles. The CLI always resolves the
 ref and materializes file-bearing run inputs; the remote backend does not need
@@ -112,7 +112,7 @@ backing changes from the live working tree to the selected revision.
 For:
 
 ```text
-sqlrs run --ref <git-ref> <run-ref> --instance <id|name>
+sqlrs run --ref <git-ref> <run-ref> --instance <id|id-prefix|name>
 ```
 
 rules are:
@@ -196,7 +196,9 @@ when full filesystem behavior matters.
 
 Ref-backed execution does not change `run` instance-selection rules:
 
-- standalone `run --ref ...` still requires `--instance <id|name>`;
+- standalone `run --ref ...` still requires `--instance <id|id-prefix|name>`
+  and uses the same exact-id/name-then-prefix resolution as live-filesystem
+  `run`;
 - conflicting instance selection remains an error;
 - `run` keeps forwarding stdout, stderr, and exit code of the executed command;
 - `run` itself still produces no additional success output.

--- a/docs/user-guides/sqlrs-run.md
+++ b/docs/user-guides/sqlrs-run.md
@@ -27,8 +27,8 @@ and test runners.
 ## Command Syntax
 
 ```text
-sqlrs run [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] <run-ref> --instance <id|name>
-sqlrs run:<kind> [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] [--instance <id|name>] [-- <command>] [args...]
+sqlrs run [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] <run-ref> --instance <id|id-prefix|name>
+sqlrs run:<kind> [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] [--instance <id|id-prefix|name>] [-- <command>] [args...]
 ```
 
 Where:
@@ -139,19 +139,24 @@ Before executing the command, `run` must resolve a target instance.
 Resolution order:
 
 1. Instance produced by a preceding `prepare` in the same invocation
-2. `--instance <id|name>`
+2. `--instance <id|id-prefix|name>`
 
 If resolution fails, `run` terminates with an error.
 
 If both `--instance` and a preceding `prepare` are present, `run` fails with an
 explicit ambiguity error.
 
-`--instance` accepts either an instance id or a name. If multiple candidates are
-found, `run` fails with an ambiguity error.
+`--instance` accepts a full instance id, an exact name, or a case-insensitive
+hex id prefix containing at least 8 characters. Resolution preserves existing
+exact-name behavior: a value that is syntactically eligible as a prefix is
+first checked as an exact id or name; only an exact miss is resolved through
+`GET /v1/instances?id_prefix=...`. A unique prefix is replaced with its full
+instance id before `POST /v1/runs`; no matches produce a not-found error and
+multiple matches produce an ambiguity error.
 
 For alias mode:
 
-- standalone `sqlrs run <run-ref>` requires `--instance <id|name>`;
+- standalone `sqlrs run <run-ref>` requires `--instance <id|id-prefix|name>`;
 - in a composite `prepare ... run <run-ref>` invocation, the run alias consumes
   the instance produced by the preceding `prepare`;
 - that composite form must not also pass `--instance`.
@@ -254,7 +259,7 @@ Hint: run sqlrs prepare:psql ... to create the instance.
 ## Options
 
 ```text
---instance <id>       Target a specific instance
+--instance <id|id-prefix|name>  Target a specific instance
 ```
 
 ---

--- a/frontend/cli-go/internal/app/run_run_test.go
+++ b/frontend/cli-go/internal/app/run_run_test.go
@@ -60,6 +60,37 @@ func TestRunRunDefaultCommandWithArgs(t *testing.T) {
 	}
 }
 
+func TestRunRunResolvesInstancePrefixBeforeExecution(t *testing.T) {
+	const fullID = "abcdef1234567890abcdef1234567890"
+	var gotRequest map[string]any
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/abcdef12":
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances":
+			if got := r.URL.Query().Get("id_prefix"); got != "abcdef12" {
+				t.Errorf("id_prefix = %q, want abcdef12", got)
+			}
+			io.WriteString(w, `[{"instance_id":"`+fullID+`"}]`)
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			body, _ := io.ReadAll(r.Body)
+			_ = json.Unmarshal(body, &gotRequest)
+			io.WriteString(w, `{"type":"exit","exit_code":0}`+"\n")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	runOpts := cli.RunOptions{Mode: "remote", Endpoint: server.URL, Timeout: time.Second}
+	if err := runRun(&bytes.Buffer{}, &bytes.Buffer{}, runOpts, "psql", []string{"--instance", "abcdef12", "--", "-c", "select 1"}, "", ""); err != nil {
+		t.Fatalf("runRun: %v", err)
+	}
+	if gotRequest["instance_ref"] != fullID {
+		t.Fatalf("instance_ref = %v, want %s", gotRequest["instance_ref"], fullID)
+	}
+}
+
 func TestRunRunArgsWithoutCommand(t *testing.T) {
 	var gotRequest map[string]any
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/frontend/cli-go/internal/cli/commands_run.go
+++ b/frontend/cli-go/internal/cli/commands_run.go
@@ -63,6 +63,10 @@ func RunRun(ctx context.Context, opts RunOptions, stdout io.Writer, stderr io.Wr
 	if err != nil {
 		return RunResult{}, err
 	}
+	instanceRef, err := resolveRunInstanceRef(ctx, cliClient, opts.InstanceRef)
+	if err != nil {
+		return RunResult{}, err
+	}
 
 	var cmdPtr *string
 	if strings.TrimSpace(opts.Command) != "" {
@@ -70,7 +74,7 @@ func RunRun(ctx context.Context, opts RunOptions, stdout io.Writer, stderr io.Wr
 		cmdPtr = &value
 	}
 	body := client.RunRequest{
-		InstanceRef: opts.InstanceRef,
+		InstanceRef: instanceRef,
 		Kind:        kind,
 		Command:     cmdPtr,
 		Args:        append([]string{}, opts.Args...),
@@ -84,6 +88,34 @@ func RunRun(ctx context.Context, opts RunOptions, stdout io.Writer, stderr io.Wr
 	defer stream.Close()
 
 	return readRunStream(stream, stdout, stderr)
+}
+
+// resolveRunInstanceRef canonicalizes prefix-shaped run targets according to
+// docs/architecture/cli-architecture.md. Ordinary names remain engine-resolved;
+// eligible prefixes preserve an exact ID/name match before list-filter lookup.
+func resolveRunInstanceRef(ctx context.Context, cliClient *client.Client, instanceRef string) (string, error) {
+	value := strings.TrimSpace(instanceRef)
+	normalized, err := normalizeIDPrefix("instance", value)
+	if err != nil {
+		return value, nil
+	}
+
+	exact, found, err := cliClient.GetInstance(ctx, value)
+	if err != nil {
+		return "", err
+	}
+	if found {
+		return exact.InstanceID, nil
+	}
+
+	match, err := resolveInstancePrefix(ctx, cliClient, normalized, "", "")
+	if err != nil {
+		return "", err
+	}
+	if match.noMatch {
+		return "", fmt.Errorf("instance not found: %s", value)
+	}
+	return match.value, nil
 }
 
 type RunStep struct {

--- a/frontend/cli-go/internal/cli/commands_run_test.go
+++ b/frontend/cli-go/internal/cli/commands_run_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -84,6 +85,257 @@ func TestRunRunRemoteStreamsOutput(t *testing.T) {
 	}
 	if errOut.String() != "warn" {
 		t.Fatalf("unexpected stderr: %q", errOut.String())
+	}
+}
+
+func TestRunRunResolvesUniqueInstancePrefix(t *testing.T) {
+	const fullID = "abcdef1234567890abcdef1234567890"
+	var exactCalls, listCalls, runCalls int
+	var gotRequest client.RunRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/ABCDEF12":
+			exactCalls++
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances":
+			listCalls++
+			if got := r.URL.Query().Get("id_prefix"); got != "abcdef12" {
+				t.Errorf("id_prefix = %q, want abcdef12", got)
+			}
+			_ = json.NewEncoder(w).Encode([]client.InstanceEntry{{InstanceID: fullID}})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			runCalls++
+			_ = json.NewDecoder(r.Body).Decode(&gotRequest)
+			w.Header().Set("Content-Type", "application/x-ndjson")
+			io.WriteString(w, `{"type":"exit","exit_code":0}`+"\n")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	_, err := RunRun(context.Background(), RunOptions{
+		Mode:        "remote",
+		Endpoint:    server.URL,
+		Kind:        "psql",
+		InstanceRef: "ABCDEF12",
+	}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("RunRun: %v", err)
+	}
+	if exactCalls != 1 || listCalls != 1 || runCalls != 1 {
+		t.Fatalf("calls: exact=%d list=%d run=%d", exactCalls, listCalls, runCalls)
+	}
+	if gotRequest.InstanceRef != fullID {
+		t.Fatalf("instance_ref = %q, want %q", gotRequest.InstanceRef, fullID)
+	}
+}
+
+func TestRunRunPrefixShapedExactNameWins(t *testing.T) {
+	const fullID = "11111111111111111111111111111111"
+	var listCalls int
+	var gotRequest client.RunRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/deadbeef":
+			_ = json.NewEncoder(w).Encode(client.InstanceEntry{InstanceID: fullID})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances":
+			listCalls++
+			_ = json.NewEncoder(w).Encode([]client.InstanceEntry{})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			_ = json.NewDecoder(r.Body).Decode(&gotRequest)
+			io.WriteString(w, `{"type":"exit","exit_code":0}`+"\n")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	_, err := RunRun(context.Background(), RunOptions{
+		Mode:        "remote",
+		Endpoint:    server.URL,
+		Kind:        "psql",
+		InstanceRef: "deadbeef",
+	}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("RunRun: %v", err)
+	}
+	if listCalls != 0 {
+		t.Fatalf("prefix list called %d times after exact match", listCalls)
+	}
+	if gotRequest.InstanceRef != fullID {
+		t.Fatalf("instance_ref = %q, want %q", gotRequest.InstanceRef, fullID)
+	}
+}
+
+func TestRunRunRejectsAmbiguousInstancePrefix(t *testing.T) {
+	var runCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/deadbeef":
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances":
+			_ = json.NewEncoder(w).Encode([]client.InstanceEntry{
+				{InstanceID: "deadbeef111111111111111111111111"},
+				{InstanceID: "deadbeef222222222222222222222222"},
+			})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			runCalls++
+			io.WriteString(w, `{"type":"exit","exit_code":0}`+"\n")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	_, err := RunRun(context.Background(), RunOptions{
+		Mode:        "remote",
+		Endpoint:    server.URL,
+		Kind:        "psql",
+		InstanceRef: "deadbeef",
+	}, &bytes.Buffer{}, &bytes.Buffer{})
+	var ambiguous *AmbiguousPrefixError
+	if !errors.As(err, &ambiguous) {
+		t.Fatalf("expected AmbiguousPrefixError, got %v", err)
+	}
+	if runCalls != 0 {
+		t.Fatalf("run called %d times for ambiguous prefix", runCalls)
+	}
+}
+
+func TestRunRunRejectsMissingInstancePrefix(t *testing.T) {
+	var runCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/cafebabe":
+			w.WriteHeader(http.StatusNotFound)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances":
+			_ = json.NewEncoder(w).Encode([]client.InstanceEntry{})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			runCalls++
+			io.WriteString(w, `{"type":"exit","exit_code":0}`+"\n")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	_, err := RunRun(context.Background(), RunOptions{
+		Mode:        "remote",
+		Endpoint:    server.URL,
+		Kind:        "psql",
+		InstanceRef: "cafebabe",
+	}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "instance not found") {
+		t.Fatalf("expected instance not found, got %v", err)
+	}
+	if runCalls != 0 {
+		t.Fatalf("run called %d times for missing prefix", runCalls)
+	}
+}
+
+func TestRunRunPropagatesInstanceLookupErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		exactCode int
+		listCode  int
+	}{
+		{name: "exact lookup", exactCode: http.StatusInternalServerError},
+		{name: "prefix list", exactCode: http.StatusNotFound, listCode: http.StatusInternalServerError},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var runCalls int
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/deadbeef":
+					w.WriteHeader(test.exactCode)
+				case r.Method == http.MethodGet && r.URL.Path == "/v1/instances":
+					w.WriteHeader(test.listCode)
+				case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+					runCalls++
+					io.WriteString(w, `{"type":"exit","exit_code":0}`+"\n")
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			_, err := RunRun(context.Background(), RunOptions{
+				Mode:        "remote",
+				Endpoint:    server.URL,
+				Kind:        "psql",
+				InstanceRef: "deadbeef",
+			}, &bytes.Buffer{}, &bytes.Buffer{})
+			if err == nil {
+				t.Fatal("expected lookup error")
+			}
+			if runCalls != 0 {
+				t.Fatalf("run called %d times after lookup error", runCalls)
+			}
+		})
+	}
+}
+
+func TestRunRunLeavesNonPrefixNameUnchanged(t *testing.T) {
+	var requestCount int
+	var gotRequest client.RunRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/runs" {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotRequest)
+		io.WriteString(w, `{"type":"exit","exit_code":0}`+"\n")
+	}))
+	defer server.Close()
+
+	_, err := RunRun(context.Background(), RunOptions{
+		Mode:        "remote",
+		Endpoint:    server.URL,
+		Kind:        "psql",
+		InstanceRef: "staging",
+	}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("RunRun: %v", err)
+	}
+	if requestCount != 1 || gotRequest.InstanceRef != "staging" {
+		t.Fatalf("requests=%d instance_ref=%q", requestCount, gotRequest.InstanceRef)
+	}
+}
+
+func TestRunRunPreservesExactFullInstanceID(t *testing.T) {
+	const fullID = "abcdef1234567890abcdef1234567890"
+	var listCalls int
+	var gotRequest client.RunRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances/"+fullID:
+			_ = json.NewEncoder(w).Encode(client.InstanceEntry{InstanceID: fullID})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/instances":
+			listCalls++
+			_ = json.NewEncoder(w).Encode([]client.InstanceEntry{})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/runs":
+			_ = json.NewDecoder(r.Body).Decode(&gotRequest)
+			io.WriteString(w, `{"type":"exit","exit_code":0}`+"\n")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	_, err := RunRun(context.Background(), RunOptions{
+		Mode:        "remote",
+		Endpoint:    server.URL,
+		Kind:        "psql",
+		InstanceRef: fullID,
+	}, &bytes.Buffer{}, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("RunRun: %v", err)
+	}
+	if listCalls != 0 || gotRequest.InstanceRef != fullID {
+		t.Fatalf("list calls=%d instance_ref=%q", listCalls, gotRequest.InstanceRef)
 	}
 }
 

--- a/frontend/cli-go/internal/cli/run_usage.go
+++ b/frontend/cli-go/internal/cli/run_usage.go
@@ -4,10 +4,10 @@ import "io"
 
 func PrintRunUsage(w io.Writer) {
 	io.WriteString(w, "Usage:\n")
-	io.WriteString(w, "  sqlrs run [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] <run-ref> --instance <id|name>\n")
-	io.WriteString(w, "  sqlrs run[:kind] [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] [--instance <id|name>] [-- <command> ] [args...]\n\n")
+	io.WriteString(w, "  sqlrs run [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] <run-ref> --instance <id|id-prefix|name>\n")
+	io.WriteString(w, "  sqlrs run[:kind] [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] [--instance <id|id-prefix|name>] [-- <command> ] [args...]\n\n")
 	io.WriteString(w, "Options:\n")
-	io.WriteString(w, "  --instance <id|name>  Target instance id or name\n")
+	io.WriteString(w, "  --instance <id|id-prefix|name>  Target instance by full id, 8+ hex prefix, or name\n")
 	io.WriteString(w, "  --ref <git-ref>       Read run inputs from a selected Git revision\n")
 	io.WriteString(w, "  --ref-mode <mode>     Ref mode: worktree (default) or blob\n")
 	io.WriteString(w, "  --ref-keep-worktree   Keep detached worktree after exit (worktree mode only)\n")

--- a/frontend/cli-go/internal/cli/run_usage_test.go
+++ b/frontend/cli-go/internal/cli/run_usage_test.go
@@ -11,10 +11,10 @@ func TestPrintRunUsageShowsAliasAndRawModes(t *testing.T) {
 	PrintRunUsage(&buf)
 
 	out := buf.String()
-	if !strings.Contains(out, "sqlrs run [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] <run-ref> --instance <id|name>") {
+	if !strings.Contains(out, "sqlrs run [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] <run-ref> --instance <id|id-prefix|name>") {
 		t.Fatalf("expected alias-mode usage, got %q", out)
 	}
-	if !strings.Contains(out, "sqlrs run[:kind] [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] [--instance <id|name>] [-- <command> ] [args...]") {
+	if !strings.Contains(out, "sqlrs run[:kind] [--ref <git-ref>] [--ref-mode worktree|blob] [--ref-keep-worktree] [--instance <id|id-prefix|name>] [-- <command> ] [args...]") {
 		t.Fatalf("expected raw-mode usage, got %q", out)
 	}
 	if !strings.Contains(out, "--ref-mode <mode>") {


### PR DESCRIPTION
## Summary

- resolve eligible instance ID prefixes before run execution
- preserve exact ID and exact name behavior, and reject missing or ambiguous prefixes
- document the CLI flow, component ownership, ADR, and roadmap status

## Testing

- targeted internal/cli and internal/app regression tests
- go test ./internal/daemon -count=1
- go test ./internal/app -count=1 -timeout=15m
- internal/cli coverage: 97.4%; changed commands_run.go: 100%

The initial parallel go test ./... run exposed existing Windows timing flakes in internal/app and internal/daemon; both packages passed when rerun independently.

Fixes #95